### PR TITLE
Change default should_requeue logic for deleted resources

### DIFF
--- a/oper8/controller.py
+++ b/oper8/controller.py
@@ -221,9 +221,10 @@ class Controller(abc.ABC):
                 "Failed to fetch current state for %s/%s/%s", namespace, kind, name
             )
             return True, requeue_params
+        # Do not requeue if resource was deleted
         if not current_state:
             log.warning("Resource not found: %s/%s/%s", namespace, kind, name)
-            return True, requeue_params
+            return False, requeue_params
 
         log.debug3("Current CR manifest for requeue check: %s", current_state)
 

--- a/oper8/test_helpers/helpers.py
+++ b/oper8/test_helpers/helpers.py
@@ -89,6 +89,7 @@ def setup_session(
     full_cr=None,
     deploy_manager=None,
     namespace=TEST_NAMESPACE,
+    deploy_initial_cr=True,
     **kwargs,
 ):
     app_config = app_config or aconfig.Config({}, override_env_vars=False)
@@ -96,7 +97,12 @@ def setup_session(
     full_cr = full_cr or setup_cr(
         deploy_config=deploy_config, version=version, namespace=namespace
     )
-    deploy_manager = deploy_manager or MockDeployManager(resources=[full_cr])
+    if not deploy_manager:
+        deploy_manager = (
+            MockDeployManager(resources=[full_cr])
+            if deploy_initial_cr
+            else MockDeployManager()
+        )
 
     return Session(
         reconciliation_id=str(uuid.uuid4()),

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -461,9 +461,9 @@ def test_should_requeue_error():
 
 
 def test_should_requeue_no_obj():
-    session = setup_session()
+    session = setup_session(deploy_initial_cr=False)
     ctrlr = DummyController()
-    assert ctrlr.should_requeue(session) == (True, RequeueParams())
+    assert ctrlr.should_requeue(session) == (False, RequeueParams())
 
 
 def test_should_requeue_failed_status():


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/IBM/oper8/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## Related Issue
Supports #?

## Related PRs
This PR is not dependent on any other PR

## What this PR does / why we need it
This PR changes the default should_requeue logic to not requeue when a resource isn't found

## Special notes for your reviewer

## If applicable**
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

## What gif most accurately describes how I feel towards this PR?
![Example of a gif](https://media.giphy.com/media/snwvCcEKk33Hy/giphy.gif)
