### PR TITLE
PermissiveFactories: Allow datastore and tls_context factories to reregister

### DIFF
--- a/oper8/x/datastores/factory_base.py
+++ b/oper8/x/datastores/factory_base.py
@@ -148,9 +148,8 @@ class DatastoreSingletonFactoryBase(abc.ABC):
         datastore_type_classes = cls._type_constructors.setdefault(
             cls.datastore_type, {}
         )
-        assert (
-            type_class.TYPE_LABEL not in datastore_type_classes
-        ), f"Got duplicate registration for {type_class.TYPE_LABEL}"
+        if type_class.TYPE_LABEL in datastore_type_classes:
+            log.warning("Got duplicate registration for %s", type_class.TYPE_LABEL)
         datastore_type_classes[type_class.TYPE_LABEL] = type_class
 
     ## Implementation Details ##################################################

--- a/oper8/x/utils/tls_context/factory.py
+++ b/oper8/x/utils/tls_context/factory.py
@@ -132,9 +132,12 @@ class _TlsContextSingletonFactory:
             f"{ITlsContext._TYPE_LABEL_ATTRIBUTE}"
         )
         type_label = getattr(context_class, ITlsContext._TYPE_LABEL_ATTRIBUTE)
-        assert type_label not in cls._registered_types, (
-            f"Received non-unique {ITlsContext._TYPE_LABEL_ATTRIBUTE} "
-            f"for {context_class}: {type_label}"
-        )
+        if type_label in cls._registered_types:
+            log.warning(
+                "Received non-unique %s for %s: %s",
+                ITlsContext._TYPE_LABEL_ATTRIBUTE,
+                context_class,
+                type_label,
+            )
         log.debug2("Registering tls context type [%s]", type_label)
         cls._registered_types[type_label] = context_class

--- a/tests/x/datastores/test_factory_base.py
+++ b/tests/x/datastores/test_factory_base.py
@@ -524,3 +524,11 @@ def test_get_connection_no_config_or_instance():
     session = setup_session(app_config=app_config_overrides)
     with pytest.raises(AssertionError):
         TestFactory.get_connection(session, instance_name)
+
+
+def test_reregister_ok():
+    """Make sure that a type can be re-registered without raising. This is
+    needed when registration is done in a derived library that uses the PWM and
+    therefore re-imports the derived implementation.
+    """
+    TestFactory.register_type(TestDatastoreOne)

--- a/tests/x/utils/test_tls_context.py
+++ b/tests/x/utils/test_tls_context.py
@@ -30,8 +30,9 @@ from oper8.x.utils import common, tls_context
 from oper8.x.utils.tls_context.factory import (
     _TlsContextSingletonFactory,
     get_tls_context,
+    register_tls_context_type,
 )
-from oper8.x.utils.tls_context.internal import InternalCaComponent
+from oper8.x.utils.tls_context.internal import InternalCaComponent, InternalTlsContext
 
 ## Helpers #####################################################################
 
@@ -491,3 +492,11 @@ def test_get_tls_context_config_overrides():
     """
     session = setup_session(app_config={"tls": {"type": "invalid"}})
     get_tls_context(session, config_overrides=INTERNAL_TLS_OVERRIDES["tls"])
+
+
+def test_reregister_ok():
+    """Make sure that a type can be re-registered without raising. This is
+    needed when registration is done in a derived library that uses the PWM and
+    therefore re-imports the derived implementation.
+    """
+    register_tls_context_type(InternalTlsContext)


### PR DESCRIPTION
## What this PR does / why we need it

When a derived library has an extended implementation of the factory base and it is registered inside the library at import time, that registration will be rerun when using the PWM with VCS enabled. Before this change, that would cause all reconciliations to raise due to a duplicate registration.

## Special notes for your reviewer

## If applicable**
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility

## What gif most accurately describes how I feel towards this PR?
![Example of a gif](https://media.giphy.com/media/3o6Zt2VoGFfkvLCMAE/giphy.gif)
