### PR TITLE
PWM Heartbeat

### DIFF
--- a/oper8/config/config.yaml
+++ b/oper8/config/config.yaml
@@ -61,6 +61,11 @@ python_watch_manager:
   watch_dependent_resources: false
   subsystem_rollout: false
 
+  # If set to a valid location, the heartbeat thread will be enabled to
+  # periodically dump the current time to the given file
+  heartbeat_file: null
+  heartbeat_period: 30s
+
   # watch filter used to reduce the amount of reconciles. The following
   # filters are available by default, or you can supply a custom filter via
   # the module.Filter notation.

--- a/oper8/config/config_validation.yaml
+++ b/oper8/config/config_validation.yaml
@@ -70,6 +70,12 @@ python_watch_manager:
   reconcile_period:
     type: str
 
+  heartbeat_file:
+    type: str
+    optional: true
+  heartbeat_period:
+    type: str
+
   process_context:
     type: str
   watch_dependent_resources:

--- a/oper8/watch_manager/python_watch_manager/python_watch_manager.py
+++ b/oper8/watch_manager/python_watch_manager/python_watch_manager.py
@@ -113,7 +113,7 @@ class PythonWatchManager(WatchManagerBase):
             watch_thread.start_thread()
         if self.heartbeat_thread:
             log.debug("Starting heartbeat_thread")
-            self.heartbeat_thread.start()
+            self.heartbeat_thread.start_thread()
         return True
 
     def wait(self):

--- a/oper8/watch_manager/python_watch_manager/threads/__init__.py
+++ b/oper8/watch_manager/python_watch_manager/threads/__init__.py
@@ -1,6 +1,7 @@
 """Import the ThreadBase and subclasses"""
 # Local
 from .base import ThreadBase
+from .heartbeat import HeartbeatThread
 from .reconcile import ReconcileThread
 from .timer import TimerThread
 from .watch import WatchThread

--- a/oper8/watch_manager/python_watch_manager/threads/heartbeat.py
+++ b/oper8/watch_manager/python_watch_manager/threads/heartbeat.py
@@ -3,12 +3,17 @@ Thread class that will dump a heartbeat to a file periodically
 """
 
 # Standard
-from datetime import datetime, timedelta
+from datetime import datetime
+import threading
+
+# First Party
+import alog
 
 # Local
-from ....exceptions import assert_config
 from ..utils import parse_time_delta
 from .timer import TimerThread
+
+log = alog.use_channel("HBEAT")
 
 
 class HeartbeatThread(TimerThread):
@@ -37,16 +42,42 @@ class HeartbeatThread(TimerThread):
         """
         self._heartbeat_file = heartbeat_file
         self._offset = parse_time_delta(heartbeat_period)
-        assert_config(
-            self._offset >= timedelta(seconds=1),
-            "heartbeat_period must be >= 1s",
-        )
+        self._beat_lock = threading.Lock()
+        self._beat_event = threading.Event()
         super().__init__(name="heartbeat_thread")
-        self.put_event(datetime.now(), self._run_heartbeat)
+
+    def run(self):
+        self._run_heartbeat()
+        return super().run()
+
+    def wait_for_beat(self):
+        """Wait for the next beat"""
+        # Make sure the beat lock is not held before starting wait. This
+        # prevents beats that are immediately ready
+        with self._beat_lock:
+            pass
+
+        # Wait for the next beat
+        self._beat_event.wait()
 
     def _run_heartbeat(self):
         """Run the heartbeat dump to the heartbeat file and put the next beat"""
         now = datetime.now()
-        with open(self._heartbeat_file, "w") as handle:
-            handle.write(now.strftime(self._DATE_FORMAT))
-        self.put_event(now + self._offset, self._run_heartbeat)
+        log.debug3("Heartbeat %s", now)
+
+        # Save the beat to disk
+        try:
+            with open(self._heartbeat_file, "w", encoding="utf-8") as handle:
+                handle.write(now.strftime(self._DATE_FORMAT))
+                handle.flush()
+        except Exception as err:
+            log.warning("Failed to write heartbeat file: %s", err, exc_info=True)
+
+        # Unblock and reset the wait condition
+        with self._beat_lock:
+            self._beat_event.set()
+            self._beat_event.clear()
+
+        # Put the next beat if not stopped
+        if not self.should_stop():
+            self.put_event(now + self._offset, self._run_heartbeat)

--- a/oper8/watch_manager/python_watch_manager/threads/heartbeat.py
+++ b/oper8/watch_manager/python_watch_manager/threads/heartbeat.py
@@ -1,0 +1,52 @@
+"""
+Thread class that will dump a heartbeat to a file periodically
+"""
+
+# Standard
+from datetime import datetime, timedelta
+
+# Local
+from ....exceptions import assert_config
+from ..utils import parse_time_delta
+from .timer import TimerThread
+
+
+class HeartbeatThread(TimerThread):
+    """The HeartbeatThread acts as a pulse for the PythonWatchManager.
+
+    This thread will periodically dump the value of "now" to a file which can be
+    read by an observer such as a liveness/readiness probe to ensure that the
+    manager is functioning well.
+    """
+
+    # This format is designed to be read using `date -d $(cat heartbeat.txt)`
+    # using the GNU date utility
+    # CITE: https://www.gnu.org/software/coreutils/manual/html_node/Examples-of-date.html
+    _DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+    def __init__(self, heartbeat_file: str, heartbeat_period: str):
+        """Initialize with the file location for the heartbeat output
+
+        Args:
+            heartbeat_file: str
+                The fully-qualified path to the heartbeat file
+            heartbeat_period: str
+                Time delta string representing period delay between beats.
+                NOTE: The GNU `date` utility cannot parse sub-seconds easily, so
+                    the expected configuration for this is to be >= 1s
+        """
+        self._heartbeat_file = heartbeat_file
+        self._offset = parse_time_delta(heartbeat_period)
+        assert_config(
+            self._offset >= timedelta(seconds=1),
+            "heartbeat_period must be >= 1s",
+        )
+        super().__init__(name="heartbeat_thread")
+        self.put_event(datetime.now(), self._run_heartbeat)
+
+    def _run_heartbeat(self):
+        """Run the heartbeat dump to the heartbeat file and put the next beat"""
+        now = datetime.now()
+        with open(self._heartbeat_file, "w") as handle:
+            handle.write(now.strftime(self._DATE_FORMAT))
+        self.put_event(now + self._offset, self._run_heartbeat)

--- a/oper8/watch_manager/python_watch_manager/threads/timer.py
+++ b/oper8/watch_manager/python_watch_manager/threads/timer.py
@@ -24,9 +24,9 @@ class TimerThread(ThreadBase, metaclass=Singleton):
     to threading.Timer stdlib class except that it uses one shared thread for all events
     instead of a thread per event."""
 
-    def __init__(self):
+    def __init__(self, name: Optional[str] = None):
         """Initialize a priorityqueue like object and a synchronization object"""
-        super().__init__(name="timer_thread", daemon=True)
+        super().__init__(name=name or "timer_thread", daemon=True)
 
         # Use a heap queue instead of a queue.PriorityQueue as we're already handling
         # synchronization with the notify condition

--- a/oper8/watch_manager/python_watch_manager/utils/types.py
+++ b/oper8/watch_manager/python_watch_manager/utils/types.py
@@ -263,7 +263,9 @@ class Singleton(type):
         if getattr(cls, "_disable_singleton", False):
             return type.__call__(cls, *args, **kwargs)
 
-        if not hasattr(cls, "_instance"):
+        # The _instance is attached to the class itself without looking upwards
+        # into any parent classes
+        if "_instance" not in cls.__dict__:
             cls._instance = type.__call__(cls, *args, **kwargs)
         return cls._instance
 

--- a/scripts/check_heartbeat.sh
+++ b/scripts/check_heartbeat.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+################################################################################
+# This utility script can be used as a kubernetes liveness/readiness probe when
+# using the python watch manager. A sample pod configuration looks like the
+# following:
+#
+# spec:
+#   ...
+#   containers:
+#     - name: operator
+#       ...
+#       env:
+#         - name: WATCH_MANAGER
+#           value: python
+#         - name: PYTHON_WATCH_MANAGER_HEARTBEAT_FILE
+#           value: /tmp/heartbeat.txt
+#       livenessProbe:
+#         exec:
+#           command:
+#             - check_heartbeat.sh
+#             - /tmp/heartbeat/txt
+#             - "120"
+#       readinessProbe:
+#         exec:
+#           command:
+#             - check_heartbeat.sh
+#             - /tmp/heartbeat/txt
+#             - "60"
+################################################################################
+
+if [ "$#" -lt "2" ]
+then
+    echo "Usage: $0 <heartbeat_file> <delta>"
+    exit 1
+fi
+
+heartbeat_file=$1
+delta=$2
+
+stamp=$(date -d "$(cat $heartbeat_file)" +%s)
+test $(expr "$stamp" + "$delta") -gt $(date +%s)

--- a/tests/watch_manager/python_watch_manager/threads/test_heartbeat.py
+++ b/tests/watch_manager/python_watch_manager/threads/test_heartbeat.py
@@ -1,0 +1,31 @@
+"""
+Tests for the HeartbeatThread
+"""
+# Standard
+from datetime import datetime, timedelta
+import tempfile
+import time
+
+# Third Party
+import pytest
+
+# Local
+from oper8.exceptions import ConfigError
+from oper8.watch_manager.python_watch_manager.threads import HeartbeatThread
+
+
+class NonSingletonHeartbeatThread(HeartbeatThread):
+    _disable_singleton = True
+
+
+def test_simple_heartbeat():
+    with tempfile.NamedTemporaryFile() as heartbeat_file:
+        hb = NonSingletonHeartbeatThread(heartbeat_file.name, "1s")
+        hb.start()
+        time.sleep(1)
+        hb.stop_thread()
+        hb.join()
+        with open(heartbeat_file.name) as handle:
+            hb_str = handle.read()
+        parsed = datetime.strptime(HeartbeatThread._DATE_FORMAT, hb_str)
+        assert parsed > (datetime.now() - timedelta(seconds=5))

--- a/tests/watch_manager/python_watch_manager/threads/test_heartbeat.py
+++ b/tests/watch_manager/python_watch_manager/threads/test_heartbeat.py
@@ -3,29 +3,89 @@ Tests for the HeartbeatThread
 """
 # Standard
 from datetime import datetime, timedelta
-import tempfile
-import time
-
-# Third Party
-import pytest
+from unittest import mock
 
 # Local
-from oper8.exceptions import ConfigError
-from oper8.watch_manager.python_watch_manager.threads import HeartbeatThread
+from oper8.test_helpers.pwm_helpers import (
+    MockedHeartbeatThread,
+    heartbeat_file,
+    read_heartbeat_file,
+)
+
+## Helpers #####################################################################
 
 
-class NonSingletonHeartbeatThread(HeartbeatThread):
-    _disable_singleton = True
+class FailOnceOpen:
+    def __init__(self, fail_on: int = 1):
+        self.call_num = 0
+        self.fail_on = fail_on
+        self._real_open = open
+
+    def __call__(self, *args, **kwargs):
+        self.call_num += 1
+        if self.call_num == self.fail_on:
+            print(f"Raising on call {self.call_num}")
+            raise OSError("Yikes")
+        print(f"Returning from call {self.call_num}")
+        return self._real_open(*args, **kwargs)
 
 
-def test_simple_heartbeat():
-    with tempfile.NamedTemporaryFile() as heartbeat_file:
-        hb = NonSingletonHeartbeatThread(heartbeat_file.name, "1s")
-        hb.start()
-        time.sleep(1)
+## Tests #######################################################################
+
+
+def test_heartbeat_happy_path(heartbeat_file):
+    """Make sure the heartbeat initializes correctly"""
+    hb = MockedHeartbeatThread(heartbeat_file, "1s")
+
+    # Heartbeat not run until started
+    with open(heartbeat_file) as handle:
+        assert not handle.read()
+
+    # Start and stop the thread to trigger the first heartbeat only
+    hb.start_thread()
+    hb.wait_for_beat()
+    hb.stop_thread()
+
+    # Make sure the heartbeat is "current"
+    assert read_heartbeat_file(heartbeat_file) > (datetime.now() - timedelta(seconds=5))
+
+
+def test_heartbeat_ongoing(heartbeat_file):
+    """Make sure that the heartbeat continues to beat in an ongoing way"""
+    hb = MockedHeartbeatThread(heartbeat_file, "1s")
+
+    # Start the thread and read the first one
+    hb.start_thread()
+    hb.wait_for_beat()
+    first_hb = read_heartbeat_file(heartbeat_file)
+
+    # Wait a bit and read again
+    hb.wait_for_beat()
+    hb.stop_thread()
+    later_hb = read_heartbeat_file(heartbeat_file)
+    assert later_hb > first_hb
+
+
+def test_heartbeat_with_exception(heartbeat_file):
+    """Make sure that a sporadic failure does not terminate the heartbeat"""
+    # Mock so that the third call to open will raise. This correlates with the
+    # second heartbeat since we read the file using open after each heartbeat
+    with mock.patch("builtins.open", new=FailOnceOpen(3)):
+        hb = MockedHeartbeatThread(heartbeat_file, "1s")
+        hb.start_thread()
+
+        # The first beat succeeds
+        hb.wait_for_beat()
+        first_hb = read_heartbeat_file(heartbeat_file)
+
+        # The first beat raises, but doesn't cause any problems
+        hb.wait_for_beat()
+        second_hb = read_heartbeat_file(heartbeat_file)
+
+        # The third beat succeeds
+        hb.wait_for_beat()
+        third_hb = read_heartbeat_file(heartbeat_file)
         hb.stop_thread()
-        hb.join()
-        with open(heartbeat_file.name) as handle:
-            hb_str = handle.read()
-        parsed = datetime.strptime(HeartbeatThread._DATE_FORMAT, hb_str)
-        assert parsed > (datetime.now() - timedelta(seconds=5))
+
+        assert first_hb == second_hb
+        assert third_hb > first_hb


### PR DESCRIPTION
## Related Issue
Supports #38 

## Related PRs
This PR is not dependent on any other PR

## What this PR does / why we need it

When using the PWM, an operator needs to be able to configure liveness/readiness probes in the `Deployment` for the operator in the cluster.

## If applicable**
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility

## What gif most accurately describes how I feel towards this PR?
![Example of a gif](https://media.giphy.com/media/9x2SEdH6d13tKgCboq/giphy.gif)
