### PR TITLE
:bug: Support valueFrom as None

### DIFF
--- a/oper8/x/utils/deps_annotation.py
+++ b/oper8/x/utils/deps_annotation.py
@@ -270,17 +270,13 @@ def _find_pod_data_deps(pod: dict) -> dict:
             value_from = env_var.get("valueFrom", {})
             if value_from:
                 # Secret reference
-                secret_name = (
-                    value_from.get("secretKeyRef", {}).get("name")
-                )
+                secret_name = value_from.get("secretKeyRef", {}).get("name")
                 if secret_name:
                     log.debug2("Found Secret env dependency: %s", secret_name)
                     deps_map.setdefault("Secret", set()).add(secret_name)
 
                 # ConfigMap reference
-                cm_name = (
-                    value_from.get("configMapKeyRef", {}).get("name")
-                )
+                cm_name = value_from.get("configMapKeyRef", {}).get("name")
                 if cm_name:
                     log.debug2("Found ConfigMap env dependency: %s", cm_name)
                     deps_map.setdefault("ConfigMap", set()).add(cm_name)

--- a/oper8/x/utils/deps_annotation.py
+++ b/oper8/x/utils/deps_annotation.py
@@ -267,21 +267,23 @@ def _find_pod_data_deps(pod: dict) -> dict:
     # env
     for container in pod_spec.get("containers", []):
         for env_var in container.get("env", []):
-            # Secret reference
-            secret_name = (
-                env_var.get("valueFrom", {}).get("secretKeyRef", {}).get("name")
-            )
-            if secret_name:
-                log.debug2("Found Secret env dependency: %s", secret_name)
-                deps_map.setdefault("Secret", set()).add(secret_name)
+            value_from = env_var.get("valueFrom", {})
+            if value_from:
+                # Secret reference
+                secret_name = (
+                    value_from.get("secretKeyRef", {}).get("name")
+                )
+                if secret_name:
+                    log.debug2("Found Secret env dependency: %s", secret_name)
+                    deps_map.setdefault("Secret", set()).add(secret_name)
 
-            # ConfigMap reference
-            cm_name = (
-                env_var.get("valueFrom", {}).get("configMapKeyRef", {}).get("name")
-            )
-            if cm_name:
-                log.debug2("Found ConfigMap env dependency: %s", cm_name)
-                deps_map.setdefault("ConfigMap", set()).add(cm_name)
+                # ConfigMap reference
+                cm_name = (
+                    value_from.get("configMapKeyRef", {}).get("name")
+                )
+                if cm_name:
+                    log.debug2("Found ConfigMap env dependency: %s", cm_name)
+                    deps_map.setdefault("ConfigMap", set()).add(cm_name)
 
     # Return the set of named deps types
     return {dep_type: sorted(list(deps)) for dep_type, deps in deps_map.items()}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/IBM/oper8/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## Related Issue
Supports #45 

## Related PRs
This PR is not dependent on any other PR

## What this PR does / why we need it

This PR supports the case where `valueFrom` is `None` - essentially not trying to process it for pod dependencies

## Special notes for your reviewer

## If applicable**
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

## What gif most accurately describes how I feel towards this PR?
![Example of a gif](https://media.giphy.com/media/snwvCcEKk33Hy/giphy.gif)
