### PR TITLE
Fall back to replace

### DIFF
--- a/oper8/config/config.yaml
+++ b/oper8/config/config.yaml
@@ -23,23 +23,31 @@ standalone: false
 strict_versioning: false
 supported_versions: []
 
-# Whether to automatically apply oper8 and kubebuilder compatible status updates to
-# custom resources
+# Whether to automatically apply oper8 and kubebuilder compatible status updates
+# to custom resources
 manage_status: true
 
 # Whether or not to apply the internal name annotation to output resources
 internal_name_annotation: true
 
-# Specify a single controller to watch, else an empty string leads to watches for all controllers
+# Specify a single controller to watch, else an empty string leads to watches
+# for all controllers
 controller_name: ""
 
 # Number of times to retry deploying
 deploy_retries: 3
 
+# Allow deployment to fall back from "patch" to "put" if patch fails with a 422.
+# This will solve certain problems where there are mutually exclusive fields
+# (e.g. value / valueFrom in an env entry) that cannot be swapped using "patch."
+# CITE: https://github.com/kubernetes/kubernetes/issues/46861
+deploy_unprocessable_put_fallback: false
+
 # Retry backoff value in seconds
 retry_backoff_base_seconds: 0.01
 
-# Wait duration in seconds until current reconciliation request is re-queued to controller runtime
+# Wait duration in seconds until current reconciliation request is re-queued to
+# controller runtime
 requeue_after_seconds: 60
 
 # Numbers of threads to use for the rollout manager (null for all available)
@@ -78,9 +86,10 @@ python_watch_manager:
   lock:
     # Set different lock types:
     # - leader-for-life: creates single lock using configmap with pod ownerRef
-    # - leader-with-lease: creates reoccurring lock using lease coordination.k8s.io/v1
-    # - annotation: apply lock as CR annotation to support multiple operator's working
-    # on the same CR
+    # - leader-with-lease: creates reoccurring lock using lease
+    #   coordination.k8s.io/v1
+    # - annotation: apply lock as CR annotation to support multiple operator's
+    #   working on the same CR
     # - null/dryrun: disabled
     type: dryrun
 


### PR DESCRIPTION
## What this PR does / why we need it

There are some circumstances where the `PATCH` verb in kubernetes will result in `422` (Unprocessable) error that can only be worked around by using the `PUT` verb instead. The only known instance of this that I'm aware of is attempting to swap a `container`'s `env` entry from using `valueFrom` to using `value` (e.g. env-based secrets to disk-based secrets).

The fix in this PR is to add a new global config `deploy_unprocessable_put_fallback` which allows the `OpenshiftDeployManager` to fall back to using `PUT` (`replace`) instead of `PATCH` (`server_side_apply`) when a 422 is encountered. Since this is a potentially risky change (using it _could_ result in replacing content that should not be replaced), the default is to leave this off, but it can be enabled via `DEPLOY_UNPROCESSABLE_PUT_FALLBACK=true` in the environment of the operator.

## Special notes for your reviewer

## If applicable**
- [x] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility

## What gif most accurately describes how I feel towards this PR?
![Example of a gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExaWFnaGo1ZmpzMXdidWQ1bmdrbzFkbm9hbHY1NG9hZ2tjcWt2dzh2YyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xTk9ZE94CfWTe2fzMI/giphy.gif)
