### PR TITLE
Add Property Accessor to Sanitization

### DIFF
--- a/oper8/utils.py
+++ b/oper8/utils.py
@@ -140,6 +140,8 @@ def sanitize_for_serialization(obj):  # pylint: disable=too-many-return-statemen
         return obj.isoformat()
     elif isinstance(obj, ResourceNode):
         return sanitize_for_serialization(obj.get_data())
+    elif isinstance(obj, property):
+        return sanitize_for_serialization(obj.fget())
 
     if isinstance(obj, dict):
         obj_dict = obj

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -168,6 +168,10 @@ def get_generic_openapi_resource_type(provided_map=None):
     class OpenApiResource:
         attribute_map = provided_map
 
+        @property
+        def property() -> str:
+            return "classproperty"
+
         def __init__(self, **kwargs):
             for k, v in kwargs.items():
                 setattr(self, k, v)
@@ -195,6 +199,7 @@ def test_sanitize_for_serialization_types():
                     "resourceNode": ResourceNode(
                         name="test", manifest={"metadata": {"name": "test"}}
                     ),
+                    "classProperty": get_generic_openapi_resource_type().property,
                     "openapiType": get_generic_openapi_resource_type(
                         {
                             "api_version": "apiVersion",
@@ -222,6 +227,7 @@ def test_sanitize_for_serialization_types():
         "spec": {
             "date": "2020-01-01T00:00:00",
             "list": ["listitem"],
+            "classProperty": "classproperty",
             "openapiType": {
                 "apiVersion": "v1",
                 "kind": "Test",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/IBM/oper8/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## Related Issue
Supports #?

## Related PRs
This PR is not dependent on any other PR

## What this PR does / why we need it
This is a small PR to add a property accessor to the `sanitize_for_serialization` function. This allows users to pass in openapi properties directly e.g. `k8s.V1Deployment.kind` without having to call `str()`.

## Special notes for your reviewer


## If applicable**
- [ ] this PR contains documentation
- [X] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

## What gif most accurately describes how I feel towards this PR?
![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMzczMGVqMWx2MDdranEzZHJ2ZWR2MWI0Zm41enllaDMxdjVkNzVibSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/42wQXwITfQbDGKqUP7/giphy.gif)
