### PR TITLE
CrossNamespaceDepsAnnotation: Handle namespaces in deps annotation

### DIFF
--- a/oper8/x/utils/deps_annotation.py
+++ b/oper8/x/utils/deps_annotation.py
@@ -21,6 +21,7 @@ import alog
 # Local
 from .constants import DEPS_ANNOTATION
 from oper8 import Component, Session
+from oper8.session import _SESSION_NAMESPACE
 from oper8.utils import merge_configs
 
 log = alog.use_channel("DEPS")
@@ -114,7 +115,7 @@ def get_deps_annotation(
     session: Session,
     dependencies: List[Union[dict, Tuple[str, str]]],
     resource_name: str = "",
-    namespace: Optional[str] = None,
+    namespace: Optional[str] = _SESSION_NAMESPACE,
 ) -> dict:
     """Get a dict holding an annotation key/value pair representing the unique
     content hash of all given dependencies. This can be used to force pods to
@@ -144,7 +145,7 @@ def get_deps_annotation(
             hash for the given set of dependencies
     """
     content_hash = hashlib.sha1()
-    namespace = namespace or session.namespace
+    namespace = namespace if namespace != _SESSION_NAMESPACE else session.namespace
     for dep in dependencies:
         # Get the dict representation depending on what type this is
         if isinstance(dep, tuple):


### PR DESCRIPTION
## Related Issue
Closes: https://github.com/IBM/oper8/issues/56

## Related PRs
This PR is not dependent on any other PR

## What this PR does / why we need it

This PR fixes the `deps-annotation` functionality when the object and data live in namespaces other than where the CR lives.

## Special notes for your reviewer

## If applicable**
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility

## What gif most accurately describes how I feel towards this PR?
![Example of a gif](https://media.giphy.com/media/3o6gEdDofO7xkaBQXK/giphy.gif?cid=ecf05e4725pf2449s9c63cnkrc0rlgx0qiwz1wraw0e9bt9d&ep=v1_gifs_search&rid=giphy.gif&ct=g)
