### PR TITLE
fix typo in Job condition check

### DIFF
--- a/oper8/verify_resources.py
+++ b/oper8/verify_resources.py
@@ -24,6 +24,7 @@ log = alog.use_channel("VERFY")
 
 DEFAULT_TIMESTAMP_KEY = "lastTransitionTime"
 AVAILABLE_CONDITION_KEY = "Available"
+COMPLETE_CONDITION_KEY = "Complete"
 PROGRESSING_CONDITION_KEY = "Progressing"
 NEW_RS_AVAILABLE_REASON = "NewReplicaSetAvailable"
 
@@ -144,7 +145,7 @@ def verify_pod(object_state: dict) -> bool:
 def verify_job(object_state: dict) -> bool:
     """Verify that a job has completed successfully"""
     # https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/job-v1/#JobStatus
-    return _verify_condition(object_state, "Completed", True)
+    return _verify_condition(object_state, COMPLETE_CONDITION_KEY, True)
 
 
 def verify_deployment(object_state: dict) -> bool:

--- a/tests/test_verify_resources.py
+++ b/tests/test_verify_resources.py
@@ -20,6 +20,7 @@ from oper8.test_helpers.helpers import (
 from oper8.utils import nested_set
 from oper8.verify_resources import (
     AVAILABLE_CONDITION_KEY,
+    COMPLETE_CONDITION_KEY,
     DEFAULT_TIMESTAMP_KEY,
     NEW_RS_AVAILABLE_REASON,
     PROGRESSING_CONDITION_KEY,
@@ -182,7 +183,9 @@ def test_verify_pod_custom_verification():
 
 def test_verify_job_completed():
     """Make sure a completed job verifies cleanly"""
-    assert run_test_verify(kind="Job", conditions=[make_condition("Completed", True)])
+    assert run_test_verify(
+        kind="Job", conditions=[make_condition(COMPLETE_CONDITION_KEY, True)]
+    )
 
 
 def test_verify_job_failed():
@@ -216,7 +219,7 @@ def test_verify_job_separate_namespace():
     """Make sure a completed job from a different namespace verifies cleanly"""
     assert run_test_verify(
         kind="Job",
-        conditions=[make_condition("Completed", True)],
+        conditions=[make_condition(COMPLETE_CONDITION_KEY, True)],
         obj_namespace="adifferent",
         search_namespace="adifferent",
     )
@@ -226,7 +229,7 @@ def test_verify_job_null_namespace():
     """Make sure a completed job in the same namespace verifies cleanly"""
     assert run_test_verify(
         kind="Job",
-        conditions=[make_condition("Completed", True)],
+        conditions=[make_condition(COMPLETE_CONDITION_KEY, True)],
         obj_namespace=TEST_NAMESPACE,
         search_namespace=_SESSION_NAMESPACE,
     )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/IBM/oper8/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## Related Issue
Supports #ISSUE_NUMBER

## Related PRs
https://github.com/IBM/oper8/pull/64

## What this PR does / why we need it
Change `Completed` to `Complete` because otherwise verify checks don't work 😞 

```
 ❯ kjobs docproc-create-bucket -o yaml | yq '.status.conditions'
- lastProbeTime: "2024-05-24T05:14:39Z"
  lastTransitionTime: "2024-05-24T05:14:39Z"
  status: "True"
  type: Complete
```

## Special notes for your reviewer

## If applicable**
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

## What gif most accurately describes how I feel towards this PR?
![Example of a gif](https://media.giphy.com/media/snwvCcEKk33Hy/giphy.gif)
