### PR TITLE
:wrench: Expose allow_from_component for get_connection

### DIFF
--- a/oper8/x/datastores/factory_base.py
+++ b/oper8/x/datastores/factory_base.py
@@ -127,6 +127,8 @@ class DatastoreSingletonFactoryBase:
             name:  Optional[str]
                 The name of the singleton instance to get. If not provided, a
                 top-level instance is used
+            allow_from_component:  bool
+                If True, use connection info from the component
 
         Returns:
             connection:  DatastoreConnectionBase


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/IBM/oper8/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## Related Issue
Supports #ISSUE_NUMBER

## Related PRs
This PR is not dependent on any other PR

## What this PR does / why we need it

Expose `allow_from_component` on `get_connection` (currently available on the private function) so that users can use this

## Special notes for your reviewer

## If applicable**
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

## What gif most accurately describes how I feel towards this PR?
![Example of a gif](https://media.giphy.com/media/snwvCcEKk33Hy/giphy.gif)
