### PR TITLE
Properly handle 422 exceptions during ConflictErrors

### DIFF
--- a/oper8/deploy_manager/openshift_deploy_manager.py
+++ b/oper8/deploy_manager/openshift_deploy_manager.py
@@ -946,4 +946,3 @@ class OpenshiftDeployManager(DeployManagerBase):
                 changed = True
 
             return changed
-            return changed


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/IBM/oper8/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## Related Issue
Supports #?

## Related PRs
This PR is not dependent on any other PR

## What this PR does / why we need it
This PR fixes a bug where a 422 raised while handling a `ConflictError` would cause reconciliation to halt.

## Special notes for your reviewer

## If applicable**
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

## What gif most accurately describes how I feel towards this PR?
![Example of a gif](https://media.giphy.com/media/snwvCcEKk33Hy/giphy.gif)
