### PR TITLE
fix for apiVersion not being set when updating status

### DIFF
--- a/oper8/reconcile.py
+++ b/oper8/reconcile.py
@@ -1001,7 +1001,7 @@ class ReconcileManager:  # pylint: disable=too-many-lines
         return status.update_resource_status(
             deploy_manager,
             manifest.kind,
-            manifest.api_version,
+            manifest.apiVersion,
             manifest.metadata.name,
             manifest.metadata.namespace,
             **kwargs,

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -1098,14 +1098,15 @@ def test_get_temp_patches(cr_manifest, patches, exception):
 def test_update_resource_status():
     """Test updating resource status"""
     dm = MockDeployManager()
-    cr = setup_cr()
+    the_api_version = "my.api/v123alpha0"
+    cr = setup_cr(api_version=the_api_version)
     rm = ReconcileManager(deploy_manager=dm)
     with mock.patch("oper8.status.update_resource_status") as Mock:
         rm._update_resource_status(dm, cr, current_status={"test": "status"})
         Mock.assert_called_with(
             dm,
             cr.kind,
-            cr.api_version,
+            the_api_version,
             cr.metadata.name,
             cr.metadata.namespace,
             current_status={"test": "status"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/IBM/oper8/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## Related Issue
Supports https://github.com/IBM/oper8/issues/72

## Related PRs
This PR is not dependent on any other PR

## What this PR does / why we need it
When `_update_resource_status` is called, we're pulling api version from the wrong field so it's set to `None`. This causes issues when multiple Kinds exist that share a name. 

Patched locally you can see the difference
```
2024-07-02T19:10:52.079619 [RECON:INFO:46915769992768] Reconciling resource WatsonDiscoveryCNM/zen/wd
2024-07-02T19:10:52.080065 [DEBUG:WARN:46915769992768] ===== updating resource status with patch ======
2024-07-02T19:10:52.080644 [DEBUG:WARN:46915199272512] OLD: None/WatsonDiscoveryCNM/wd
2024-07-02T19:10:52.080847 [DEBUG:WARN:46915769992768] NEW: discovery.watson.ibm.com/v1/WatsonDiscoveryCNM/wd
2024-07-02T19:10:52.081029 [DEBUG:WARN:46915769992768] ===== updating resource status with patch ======
```

## Special notes for your reviewer

## If applicable**
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

## What gif most accurately describes how I feel towards this PR?
![Example of a gif](https://media1.tenor.com/m/KRS1qz0uobkAAAAd/pulp-fiction-john-travolta.gif)
