### PR TITLE
Add replace functionality to DeployManager

### DIFF
--- a/oper8/component.py
+++ b/oper8/component.py
@@ -193,7 +193,7 @@ class Component(Node, abc.ABC):
         for obj in self.managed_objects:
             success, _ = session.deploy_manager.deploy(
                 resource_definitions=[obj.definition],
-                method=obj.deploy_method or DeployMethod.DEFAULT,
+                method=obj.deploy_method,
             )
             if not success:
                 log.warning("Failed to deploy [%s]", self)

--- a/oper8/config/config.yaml
+++ b/oper8/config/config.yaml
@@ -43,6 +43,14 @@ deploy_retries: 3
 # CITE: https://github.com/kubernetes/kubernetes/issues/46861
 deploy_unprocessable_put_fallback: false
 
+# List to keep track of all Kubernetes and Openshift annotations that should be retained
+# on resources
+cluster_passthrough_annotations:
+  - "kubernetes.io"
+  - "openshift.io"
+  - "k8s.ovn.org"
+  - "cncf.io"
+
 # Retry backoff value in seconds
 retry_backoff_base_seconds: 0.01
 

--- a/oper8/constants.py
+++ b/oper8/constants.py
@@ -31,6 +31,15 @@ PASSTHROUGH_ANNOTATIONS = [
     PAUSE_ANNOTATION_NAME,
 ]
 
+# List to keep track of all Kubernetes and Openshift annotations that should be retained
+# on resources
+CLUSTER_CONTROLLER_ANNOTATIONS = [
+    "kubernetes.io",
+    "openshift.io",
+    "k8s.ovn.org",
+    "cncf.io",
+]
+
 # BACKWARDS COMPATIBILITY: We maintain the ALL_ANNOTATIONS name for
 # compatibility with old code that accessed this directly
 ALL_ANNOTATIONS = PASSTHROUGH_ANNOTATIONS

--- a/oper8/constants.py
+++ b/oper8/constants.py
@@ -31,15 +31,6 @@ PASSTHROUGH_ANNOTATIONS = [
     PAUSE_ANNOTATION_NAME,
 ]
 
-# List to keep track of all Kubernetes and Openshift annotations that should be retained
-# on resources
-CLUSTER_CONTROLLER_ANNOTATIONS = [
-    "kubernetes.io",
-    "openshift.io",
-    "k8s.ovn.org",
-    "cncf.io",
-]
-
 # BACKWARDS COMPATIBILITY: We maintain the ALL_ANNOTATIONS name for
 # compatibility with old code that accessed this directly
 ALL_ANNOTATIONS = PASSTHROUGH_ANNOTATIONS

--- a/oper8/dag/node.py
+++ b/oper8/dag/node.py
@@ -128,6 +128,9 @@ class ResourceNode(Node):
         super().__init__(name, manifest)
         self._verify_function = verify_func
         self._deploy_method = deploy_method
+        if not deploy_method:
+            from ..deploy_manager import DeployMethod
+            self._deploy_method = DeployMethod.DEFAULT
 
     ## ApiObject Parameters and Functions ######################################
     @property

--- a/oper8/dag/node.py
+++ b/oper8/dag/node.py
@@ -118,11 +118,16 @@ class ResourceNode(Node):
     a function for verifying said resource"""
 
     def __init__(
-        self, name: str, manifest: dict, verify_func: Optional[Callable] = None
+        self,
+        name: str,
+        manifest: dict,
+        verify_func: Optional[Callable] = None,
+        deploy_method: Optional["DeployMethod"] = None,  # noqa: F821
     ):
         # Override init to require name/manifest parameters
         super().__init__(name, manifest)
         self._verify_function = verify_func
+        self._deploy_method = deploy_method
 
     ## ApiObject Parameters and Functions ######################################
     @property
@@ -159,6 +164,11 @@ class ResourceNode(Node):
     def verify_function(self) -> Optional[Callable]:
         """The resource manifest"""
         return self._verify_function
+
+    @property
+    def deploy_method(self) -> Optional["DeployMethod"]:  # noqa: F821
+        """The resource manifest"""
+        return self._deploy_method
 
     def add_dependency(self, node: "ResourceNode"):
         """Add a child dependency to this node"""

--- a/oper8/dag/node.py
+++ b/oper8/dag/node.py
@@ -129,7 +129,9 @@ class ResourceNode(Node):
         self._verify_function = verify_func
         self._deploy_method = deploy_method
         if not deploy_method:
+            # Local
             from ..deploy_manager import DeployMethod
+
             self._deploy_method = DeployMethod.DEFAULT
 
     ## ApiObject Parameters and Functions ######################################

--- a/oper8/deploy_manager/__init__.py
+++ b/oper8/deploy_manager/__init__.py
@@ -4,7 +4,7 @@ kubernetes cluster to deploy, look up, and delete resources.
 """
 
 # Local
-from .base import DeployManagerBase
+from .base import DeployManagerBase, DeployMethod
 from .dry_run_deploy_manager import DryRunDeployManager
 from .kube_event import KubeEventType, KubeWatchEvent
 from .openshift_deploy_manager import OpenshiftDeployManager

--- a/oper8/deploy_manager/base.py
+++ b/oper8/deploy_manager/base.py
@@ -3,11 +3,18 @@ This defines the base class for all DeployManager types.
 """
 
 # Standard
+from enum import Enum
 from typing import Iterator, List, Optional, Tuple
 import abc
 
 # Local
 from .kube_event import KubeWatchEvent
+
+
+class DeployMethod(Enum):
+    DEFAULT = "default"
+    UPDATE = "update"
+    REPLACE = "replace"
 
 
 class DeployManagerBase(abc.ABC):
@@ -21,6 +28,7 @@ class DeployManagerBase(abc.ABC):
         self,
         resource_definitions: List[dict],
         manage_owner_references: bool = True,
+        method: DeployMethod = DeployMethod.DEFAULT,
     ) -> Tuple[bool, bool]:
         """The deploy function ensures that the resources defined in the list of
         definitions are deployed in the cluster.

--- a/oper8/deploy_manager/openshift_deploy_manager.py
+++ b/oper8/deploy_manager/openshift_deploy_manager.py
@@ -705,7 +705,7 @@ class OpenshiftDeployManager(DeployManagerBase):
 
         change = bool(requires_replace(manifest_a, manifest_b))
         log.debug2("Requires Replace? %s", change)
-
+        return change
     # Internal struct to hold the key resource identifier elements
     _ResourceIdentifiers = namedtuple(
         "ResourceIdentifiers", ["api_version", "kind", "name", "namespace"]

--- a/oper8/deploy_manager/openshift_deploy_manager.py
+++ b/oper8/deploy_manager/openshift_deploy_manager.py
@@ -905,6 +905,14 @@ class OpenshiftDeployManager(DeployManagerBase):
             if method == DeployMethod.DEFAULT:
                 req_replace = self._requires_replace(current, resource_definition)
 
+            log.debug2(
+                "Attempting to deploy [%s/%s/%s] in %s with %s",
+                api_version,
+                kind,
+                name,
+                namespace,
+                method,
+            )
             # If the resource requires a replace operation then use put. Otherwise use
             # server side apply
             if (

--- a/oper8/deploy_manager/openshift_deploy_manager.py
+++ b/oper8/deploy_manager/openshift_deploy_manager.py
@@ -40,6 +40,7 @@ from ..verify_resources import verify_subsystem
 from .base import DeployManagerBase
 from .kube_event import KubeEventType, KubeWatchEvent
 from .owner_references import update_owner_references
+from .replace_utils import requires_replace
 
 log = alog.use_channel("OSFTD")
 
@@ -50,7 +51,6 @@ log = alog.use_channel("OSFTD")
 # https://github.com/kubernetes-client/python/blob/master/examples/watch/timeout-settings.md
 SERVER_WATCH_TIMEOUT = 3600
 CLIENT_WATCH_TIMEOUT = 30
-
 
 class OpenshiftDeployManager(DeployManagerBase):
     """This DeployManager uses the openshift DynamicClient to interact with the
@@ -653,9 +653,12 @@ class OpenshiftDeployManager(DeployManagerBase):
         log.debug4("Status With Ansible: %s", status)
 
     @classmethod
-    def _manifest_diff(cls, manifest_a, manifest_b):
+    def _manifest_diff(cls, manifest_a, manifest_b) -> bool:
         """Helper to compare two manifests for meaningful diff while ignoring
-        fields that always change
+        fields that always change. 
+
+        Returns:
+            [bool, bool]: The first bool identifies if the resource changed while the
         """
         manifest_a = copy.deepcopy(manifest_a)
         manifest_b = copy.deepcopy(manifest_b)
@@ -705,6 +708,43 @@ class OpenshiftDeployManager(DeployManagerBase):
     ## Operations ##
     ################
 
+    def _replace_resource(self, resource_definition: dict) -> dict:
+        """Helper function to forcibly replace a resource on the cluster"""
+        # Get the key elements of the resource
+        res_id = self._get_resource_identifiers(resource_definition)
+        api_version = res_id.api_version
+        kind = res_id.kind
+        name = res_id.name
+        namespace = res_id.namespace
+
+        # Strip out managedFields to let the sever set them
+        resource_definition["metadata"]["managedFields"] = None
+
+        # Get the resource handle
+        log.debug2("Fetching resource handle [%s/%s]", api_version, kind)
+        resource_handle = self._get_resource_handle(api_version=api_version, kind=kind)
+        assert_cluster(
+            resource_handle,
+            (
+                "Failed to fetch resource handle for "
+                + f"{namespace}/{api_version}/{kind}"
+            ),
+        )
+
+        log.debug2(
+            "Attempting to put [%s/%s/%s] in %s",
+            api_version,
+            kind,
+            name,
+            namespace,
+        )
+        return resource_handle.replace(
+            resource_definition,
+            name=name,
+            namespace=namespace,
+            field_manager="oper8",
+        ).to_dict()
+        
     def _apply_resource(self, resource_definition: dict) -> dict:
         """Helper function to apply a single resource to the cluster"""
         # Get the key elements of the resource
@@ -743,45 +783,20 @@ class OpenshiftDeployManager(DeployManagerBase):
                 field_manager="oper8",
             ).to_dict()
         except ConflictError:
-            try:
-                log.debug(
-                    "Overriding field manager conflict for [%s/%s/%s] in %s ",
-                    api_version,
-                    kind,
-                    name,
-                    namespace,
-                )
-                return resource_handle.server_side_apply(
-                    resource_definition,
-                    name=name,
-                    namespace=namespace,
-                    field_manager="oper8",
-                    force_conflicts=True,
-                ).to_dict()
-            except UnprocessibleEntityError as err:
-                log.debug3("Caught 422 error: %s", err, exc_info=True)
-                if config.deploy_unprocessable_put_fallback:
-                    log.debug("Falling back to PUT on 422: %s", err)
-                    return resource_handle.replace(
-                        resource_definition,
-                        name=name,
-                        namespace=namespace,
-                        field_manager="oper8",
-                    ).to_dict()
-                else:
-                    raise
-        except UnprocessibleEntityError as err:
-            log.debug3("Caught 422 error: %s", err, exc_info=True)
-            if config.deploy_unprocessable_put_fallback:
-                log.debug("Falling back to PUT on 422: %s", err)
-                return resource_handle.replace(
-                    resource_definition,
-                    name=name,
-                    namespace=namespace,
-                    field_manager="oper8",
-                ).to_dict()
-            else:
-                raise
+            log.debug(
+                "Overriding field manager conflict for [%s/%s/%s] in %s ",
+                api_version,
+                kind,
+                name,
+                namespace,
+            )
+            return resource_handle.server_side_apply(
+                resource_definition,
+                name=name,
+                namespace=namespace,
+                field_manager="oper8",
+                force_conflicts=True,
+            ).to_dict()
 
     def _apply(self, resource_definition):
         """Apply a single resource to the cluster
@@ -825,7 +840,27 @@ class OpenshiftDeployManager(DeployManagerBase):
 
         # If there is meaningful change, apply this instance
         if changed:
-            apply_res = self._apply_resource(resource_definition)
+            
+            req_replace = requires_replace(current, resource_definition)
+            
+            # If the resource requires a replace operation then use put. Otherwise use
+            # server side apply
+            if req_replace:
+                apply_res = self._replace_resource(
+                    resource_definition,
+                )
+            else:
+                try:
+                    apply_res = self._apply_resource(resource_definition)
+                except UnprocessibleEntityError as err:
+                    log.debug3("Caught 422 error: %s", err, exc_info=True)
+                    if config.deploy_unprocessable_put_fallback:
+                        log.debug("Falling back to PUT on 422: %s", err)
+                        apply_res = self._replace_resource(
+                            resource_definition,
+                        )
+                    else:
+                        raise
 
             # Recompute the diff to determine if the apply actually caused a
             # meaningful change. This may have a different result than the check

--- a/oper8/deploy_manager/openshift_deploy_manager.py
+++ b/oper8/deploy_manager/openshift_deploy_manager.py
@@ -34,7 +34,6 @@ import alog
 # Local
 from .. import config
 from .. import status as oper8_status
-from ..constants import CLUSTER_CONTROLLER_ANNOTATIONS
 from ..exceptions import assert_cluster
 from ..managed_object import ManagedObject
 from ..verify_resources import verify_subsystem
@@ -658,6 +657,12 @@ class OpenshiftDeployManager(DeployManagerBase):
 
     @classmethod
     def _clean_manifest(cls, manifest_a: dict, manifest_b: dict) -> Tuple[dict, dict]:
+        """Clean two manifests before being compared. This removes fields that
+        change every reconcile
+
+        Returns:
+            Tuple[dict, dict]: The cleaned manifests
+        """
         manifest_a = copy.deepcopy(manifest_a)
         manifest_b = copy.deepcopy(manifest_b)
         for metadata_field in [
@@ -694,26 +699,23 @@ class OpenshiftDeployManager(DeployManagerBase):
         return change
 
     @classmethod
-    def _retain_kubernetes_annotations(cls, current: dict, desired: dict) -> bool:
-        """Helper to compare two manifests for meaningful diff while ignoring
-        fields that always change.
+    def _retain_kubernetes_annotations(cls, current: dict, desired: dict) -> dict:
+        """Helper to update a desired manifest with certain annotations from the existing
+        resource. This stops other controllers from re-reconciling this resource
 
         Returns:
-            [bool, bool]: The first bool identifies if the resource changed while the
+            dict: updated resource
         """
 
         identifiers = cls._get_resource_identifiers(desired)
-        if "annotations" not in desired["metadata"]:
-            desired["metadata"]["annotations"] = {}
 
         for annotation, annotation_value in (
             current.get("metadata", {}).get("annotations", {}).items()
         ):
-            for cluster_annotation in CLUSTER_CONTROLLER_ANNOTATIONS:
-                if (
-                    cluster_annotation in annotation
-                    and annotation not in desired["metadata"]["annotations"]
-                ):
+            for cluster_annotation in config.cluster_passthrough_annotations:
+                if cluster_annotation in annotation and annotation not in desired[
+                    "metadata"
+                ].get("annotations", {}):
                     log.debug4(
                         "Retaining annotation %s for [%s/%s/%s]",
                         annotation,
@@ -721,7 +723,9 @@ class OpenshiftDeployManager(DeployManagerBase):
                         identifiers.api_version,
                         identifiers.name,
                     )
-                    desired["metadata"]["annotations"][annotation] = annotation_value
+                    desired["metadata"].setdefault("annotations", {})[
+                        annotation
+                    ] = annotation_value
         return desired
 
     @classmethod
@@ -902,7 +906,7 @@ class OpenshiftDeployManager(DeployManagerBase):
             )
 
             req_replace = False
-            if method == DeployMethod.DEFAULT:
+            if method is DeployMethod.DEFAULT:
                 req_replace = self._requires_replace(current, resource_definition)
 
             log.debug2(
@@ -916,7 +920,7 @@ class OpenshiftDeployManager(DeployManagerBase):
             # If the resource requires a replace operation then use put. Otherwise use
             # server side apply
             if (
-                req_replace or method == DeployMethod.REPLACE
+                req_replace or method is DeployMethod.REPLACE
             ) and method != DeployMethod.UPDATE:
                 apply_res = self._replace_resource(
                     resource_definition,

--- a/oper8/deploy_manager/openshift_deploy_manager.py
+++ b/oper8/deploy_manager/openshift_deploy_manager.py
@@ -706,6 +706,7 @@ class OpenshiftDeployManager(DeployManagerBase):
         change = bool(requires_replace(manifest_a, manifest_b))
         log.debug2("Requires Replace? %s", change)
         return change
+
     # Internal struct to hold the key resource identifier elements
     _ResourceIdentifiers = namedtuple(
         "ResourceIdentifiers", ["api_version", "kind", "name", "namespace"]
@@ -864,7 +865,9 @@ class OpenshiftDeployManager(DeployManagerBase):
         # If there is meaningful change, apply this instance
         if changed:
 
-            req_replace = self._requires_replace(current, resource_definition)
+            req_replace = False
+            if method == DeployMethod.DEFAULT:
+                req_replace = self._requires_replace(current, resource_definition)
 
             # If the resource requires a replace operation then use put. Otherwise use
             # server side apply

--- a/oper8/deploy_manager/replace_utils.py
+++ b/oper8/deploy_manager/replace_utils.py
@@ -36,7 +36,7 @@ def modified_value_from(current_manifest: Any, desired_manifest: Any) -> bool:
     exclusive thus they require a replace command.
     """
     if isinstance(current_manifest, list) and isinstance(desired_manifest, list):
-        iteration_len = min(len(current_manifest), desired_manifest)
+        iteration_len = min(len(current_manifest), len(desired_manifest))
         for i in range(iteration_len):
             if modified_value_from(current_manifest[i], desired_manifest[i]):
                 return True

--- a/oper8/deploy_manager/replace_utils.py
+++ b/oper8/deploy_manager/replace_utils.py
@@ -1,0 +1,67 @@
+"""This file contains common utilities for detecting if a replace operation is required
+for a resource
+"""
+# Standard
+from typing import Any, Callable, List
+
+# First Party
+import alog
+# Third Party
+from openshift.dynamic.apply import recursive_list_diff
+
+log = alog.use_channel("DMRPLC_UTILS")
+
+
+
+def modified_lists(current_manifest: dict, desired_manifest: dict) -> bool:
+    """Helper function to check if there are any differences in the lists of the desired manifest. This
+    is required because Kubernetes combines lists which is often not the desired use
+    """
+    for k in (set(current_manifest.keys()).intersection(set(desired_manifest.keys()))):
+        if isinstance(current_manifest[k], list) and isinstance(desired_manifest[k], list):
+            if bool(recursive_list_diff(current_manifest[k], desired_manifest[k])):
+                return True
+        elif isinstance(current_manifest[k], dict) and isinstance(desired_manifest[k], dict):
+            if modified_lists(current_manifest[k], desired_manifest[k]):
+                return True
+    return False
+
+def modified_value_from(current_manifest: Any, desired_manifest: Any)->bool:
+    """Helper function to check if a manifest switched from value to valueFrom. These are mutually
+    exclusive thus they require a replace command.
+    """
+    if isinstance(current_manifest, list) and isinstance(desired_manifest, list):
+        iteration_len = min(len(current_manifest), desired_manifest)
+        for i in range(iteration_len):
+            if modified_value_from(current_manifest[i], desired_manifest[i]):
+                return True
+    if isinstance(current_manifest, dict) and isinstance(desired_manifest, dict):
+        if ("value" in current_manifest and "valueFrom" in desired_manifest) or ("valueFrom" in current_manifest and "value" in desired_manifest):
+            return True
+        else:
+            for k in (set(current_manifest.keys()).intersection(set(desired_manifest.keys()))):
+                if modified_value_from(current_manifest[k], desired_manifest[k]):
+                    return True
+    return False
+            
+            
+REPLACE_FUNCS:List[Callable[[str, str], bool]] = [modified_lists, modified_value_from]
+
+
+def requires_replace(current_manifest: dict, desired_manifest: dict)->bool:
+    """Function to determine if a resource requires a replace operation instead 
+    of apply. This can occur due to list merging, or updating envVars
+
+    Args:
+        current_manifest (dict): The current manifest in the cluster
+        desired_manifest (dict): The desired manifest that should be applied
+
+    Returns:
+        bool: If the current manifest requires a replace operation
+    """
+    for func in REPLACE_FUNCS:
+        if func(current_manifest, desired_manifest):
+            log.debug4("Manifest requires replace", desired_manifest)
+            return True
+    return False
+    

--- a/oper8/deploy_manager/replace_utils.py
+++ b/oper8/deploy_manager/replace_utils.py
@@ -4,29 +4,34 @@ for a resource
 # Standard
 from typing import Any, Callable, List
 
-# First Party
-import alog
 # Third Party
 from openshift.dynamic.apply import recursive_list_diff
+
+# First Party
+import alog
 
 log = alog.use_channel("DMRPLC_UTILS")
 
 
-
 def modified_lists(current_manifest: dict, desired_manifest: dict) -> bool:
-    """Helper function to check if there are any differences in the lists of the desired manifest. This
-    is required because Kubernetes combines lists which is often not the desired use
+    """Helper function to check if there are any differences in the lists of the desired manifest.
+    This is required because Kubernetes combines lists which is often not the desired use
     """
-    for k in (set(current_manifest.keys()).intersection(set(desired_manifest.keys()))):
-        if isinstance(current_manifest[k], list) and isinstance(desired_manifest[k], list):
+    for k in set(current_manifest.keys()).intersection(set(desired_manifest.keys())):
+        if isinstance(current_manifest[k], list) and isinstance(
+            desired_manifest[k], list
+        ):
             if bool(recursive_list_diff(current_manifest[k], desired_manifest[k])):
                 return True
-        elif isinstance(current_manifest[k], dict) and isinstance(desired_manifest[k], dict):
+        elif isinstance(current_manifest[k], dict) and isinstance(  # noqa: SIM102
+            desired_manifest[k], dict
+        ):
             if modified_lists(current_manifest[k], desired_manifest[k]):
                 return True
     return False
 
-def modified_value_from(current_manifest: Any, desired_manifest: Any)->bool:
+
+def modified_value_from(current_manifest: Any, desired_manifest: Any) -> bool:
     """Helper function to check if a manifest switched from value to valueFrom. These are mutually
     exclusive thus they require a replace command.
     """
@@ -36,20 +41,24 @@ def modified_value_from(current_manifest: Any, desired_manifest: Any)->bool:
             if modified_value_from(current_manifest[i], desired_manifest[i]):
                 return True
     if isinstance(current_manifest, dict) and isinstance(desired_manifest, dict):
-        if ("value" in current_manifest and "valueFrom" in desired_manifest) or ("valueFrom" in current_manifest and "value" in desired_manifest):
+        if ("value" in current_manifest and "valueFrom" in desired_manifest) or (
+            "valueFrom" in current_manifest and "value" in desired_manifest
+        ):
             return True
         else:
-            for k in (set(current_manifest.keys()).intersection(set(desired_manifest.keys()))):
+            for k in set(current_manifest.keys()).intersection(
+                set(desired_manifest.keys())
+            ):
                 if modified_value_from(current_manifest[k], desired_manifest[k]):
                     return True
     return False
-            
-            
-REPLACE_FUNCS:List[Callable[[str, str], bool]] = [modified_lists, modified_value_from]
 
 
-def requires_replace(current_manifest: dict, desired_manifest: dict)->bool:
-    """Function to determine if a resource requires a replace operation instead 
+REPLACE_FUNCS: List[Callable[[str, str], bool]] = [modified_lists, modified_value_from]
+
+
+def requires_replace(current_manifest: dict, desired_manifest: dict) -> bool:
+    """Function to determine if a resource requires a replace operation instead
     of apply. This can occur due to list merging, or updating envVars
 
     Args:
@@ -64,4 +73,3 @@ def requires_replace(current_manifest: dict, desired_manifest: dict)->bool:
             log.debug4("Manifest requires replace", desired_manifest)
             return True
     return False
-    

--- a/oper8/managed_object.py
+++ b/oper8/managed_object.py
@@ -11,7 +11,12 @@ KUBE_LIST_IDENTIFIER = "List"
 class ManagedObject:  # pylint: disable=too-many-instance-attributes
     """Basic struct to represent a managed kubernetes object"""
 
-    def __init__(self, definition: dict, verify_function: Optional[Callable] = None):
+    def __init__(
+        self,
+        definition: dict,
+        verify_function: Optional[Callable] = None,
+        deploy_method: Optional["DeployMethod"] = None,  # noqa: F821
+    ):
         self.kind = definition.get("kind")
         self.metadata = definition.get("metadata", {})
         self.name = self.metadata.get("name")
@@ -21,6 +26,7 @@ class ManagedObject:  # pylint: disable=too-many-instance-attributes
         self.api_version = definition.get("apiVersion")
         self.definition = definition
         self.verify_function = verify_function
+        self.deploy_method = deploy_method
 
         # If resource is not list then check name
         if KUBE_LIST_IDENTIFIER not in self.kind:

--- a/oper8/test_helpers/kub_mock.py
+++ b/oper8/test_helpers/kub_mock.py
@@ -312,7 +312,9 @@ class MockKubClient(kubernetes.client.ApiClient):
                 endpoint = f"{api_endpoint}/{kind_variant}/*"
 
             log.debug2(
-                "Adding POST & GET & WATCH & PATCH handler for (%s: %s)", kind, endpoint
+                "Adding POST & PUT &GET & WATCH & PATCH handler for (%s: %s)",
+                kind,
+                endpoint,
             )
             self._handlers[endpoint] = {
                 "WATCH": lambda resource_path, body, *_, **__: (
@@ -321,6 +323,9 @@ class MockKubClient(kubernetes.client.ApiClient):
                     )
                 ),
                 "PATCH": lambda resource_path, body, *_, **__: (
+                    self.current_state_patch(resource_path, api_version, kind, body)
+                ),
+                "PUT": lambda resource_path, body, *_, **__: (
                     self.current_state_patch(resource_path, api_version, kind, body)
                 ),
                 "POST": lambda resource_path, body, *_, **__: (

--- a/oper8/test_helpers/kub_mock.py
+++ b/oper8/test_helpers/kub_mock.py
@@ -312,7 +312,7 @@ class MockKubClient(kubernetes.client.ApiClient):
                 endpoint = f"{api_endpoint}/{kind_variant}/*"
 
             log.debug2(
-                "Adding POST & PUT &GET & WATCH & PATCH handler for (%s: %s)",
+                "Adding POST & PUT & GET & WATCH & PATCH handler for (%s: %s)",
                 kind,
                 endpoint,
             )

--- a/tests/deploy_manager/test_replace_utils.py
+++ b/tests/deploy_manager/test_replace_utils.py
@@ -11,7 +11,7 @@ import pytest
 import alog
 
 # Local
-from oper8.deploy_manager.replace_utils import requires_replace, REPLACE_FUNCS
+from oper8.deploy_manager.replace_utils import REPLACE_FUNCS, requires_replace
 
 ## Helpers #####################################################################
 
@@ -84,7 +84,7 @@ def test_value_operations(desired_obj):
 
 
 @pytest.mark.parametrize(
-    ["desired_obj"],
+    ["desired_obj", "requires"],
     [
         [
             {
@@ -93,14 +93,16 @@ def test_value_operations(desired_obj):
                     {"name": "container2"},
                     {"name": "container3"},
                 ],
-            }
+            },
+            False,
         ],
         [
             {
                 "list": [
                     {"name": "container1"},
                 ],
-            }
+            },
+            True,
         ],
         [
             {
@@ -108,17 +110,28 @@ def test_value_operations(desired_obj):
                     {"name": "container1"},
                     {"name": "container_changed"},
                 ],
-            }
+            },
+            True,
+        ],
+        [
+            {
+                "list": [
+                    {"name": "container1"},
+                    {"name": "container4"},
+                ],
+            },
+            True,
         ],
     ],
 )
-def test_list_operations(desired_obj):
+def test_list_operations(desired_obj, requires) -> None:
     """Test that adding a ref to an object with none present adds as expected"""
     current_obj = sample_object()
-    assert requires_replace(current_obj, desired_obj)
+    assert requires_replace(current_obj, desired_obj) == requires
     # Ensure each replace function is still able to be called
     for func in REPLACE_FUNCS:
         func(current_obj, desired_obj)
+
 
 ## Patch functions ##################################################################
 

--- a/tests/deploy_manager/test_replace_utils.py
+++ b/tests/deploy_manager/test_replace_utils.py
@@ -1,0 +1,128 @@
+"""
+Tests for the replace_utils functionality
+"""
+
+# Standard
+
+# First Party
+import alog
+
+# Third Party
+import pytest
+# Local
+from oper8.deploy_manager.replace_utils import requires_replace
+
+## Helpers #####################################################################
+
+log = alog.use_channel("TEST")
+
+
+def sample_object():
+    return {
+            "original_value": "original",
+            "envs": [
+                {
+                    "name": "first",
+                    "value": "True",
+                },
+                {
+                    "name": "second",
+                    "valueFrom": "False",
+                }
+            ],
+            "list":[
+                {"name":"container1"},
+                {"name":"container2"},
+            ]
+        }
+
+
+## Replace functions ##################################################################
+
+@pytest.mark.parametrize(
+    ["desired_obj"],
+    [
+        [{
+            "envs": [
+                {
+                    "name": "first",
+                    "valueFrom": "True",
+                },
+                {
+                    "name": "second",
+                    "valueFrom": "False",
+                }
+            ],
+        }],
+        [{
+            "envs": [
+                {
+                    "name": "first",
+                    "value": "True",
+                },
+                {
+                    "name": "second",
+                    "value": "True",
+                }
+            ],
+        }],
+    ],
+)
+def test_value_operations(desired_obj):
+    """Test that adding a ref to an object with none present adds as expected"""
+    current_obj = sample_object()
+    assert requires_replace(current_obj, desired_obj)
+
+
+@pytest.mark.parametrize(
+    ["desired_obj"],
+    [
+        [{
+            "list": [
+                {"name":"container1"},
+                {"name":"container2"},
+                {"name":"container3"},
+            ],
+        }],
+        [{
+            "list": [
+                {"name":"container1"},
+            ],
+        }],
+        [{
+            "list": [
+                {"name":"container1"},
+                {"name":"container_changed"},
+            ],
+        }],
+    ],
+)
+def test_list_operations(desired_obj):
+    """Test that adding a ref to an object with none present adds as expected"""
+    current_obj = sample_object()
+    assert requires_replace(current_obj, desired_obj)
+
+
+## Patch functions ##################################################################
+
+
+@pytest.mark.parametrize(
+    ["desired_obj"],
+    [
+        [{
+            "new_value": "patched"
+        }],
+        [{
+            "added_list": [
+                {"new_value"}
+            ]
+        }],
+        [{
+            "original_value": 'patched'
+        }],
+        
+    ],
+)
+def test_patch_operations(desired_obj):
+    current_obj = sample_object()
+    assert not requires_replace(current_obj, desired_obj)

--- a/tests/deploy_manager/test_replace_utils.py
+++ b/tests/deploy_manager/test_replace_utils.py
@@ -4,11 +4,12 @@ Tests for the replace_utils functionality
 
 # Standard
 
+# Third Party
+import pytest
+
 # First Party
 import alog
 
-# Third Party
-import pytest
 # Local
 from oper8.deploy_manager.replace_utils import requires_replace
 
@@ -19,53 +20,58 @@ log = alog.use_channel("TEST")
 
 def sample_object():
     return {
-            "original_value": "original",
-            "envs": [
-                {
-                    "name": "first",
-                    "value": "True",
-                },
-                {
-                    "name": "second",
-                    "valueFrom": "False",
-                }
-            ],
-            "list":[
-                {"name":"container1"},
-                {"name":"container2"},
-            ]
-        }
+        "original_value": "original",
+        "envs": [
+            {
+                "name": "first",
+                "value": "True",
+            },
+            {
+                "name": "second",
+                "valueFrom": "False",
+            },
+        ],
+        "list": [
+            {"name": "container1"},
+            {"name": "container2"},
+        ],
+    }
 
 
 ## Replace functions ##################################################################
 
+
 @pytest.mark.parametrize(
     ["desired_obj"],
     [
-        [{
-            "envs": [
-                {
-                    "name": "first",
-                    "valueFrom": "True",
-                },
-                {
-                    "name": "second",
-                    "valueFrom": "False",
-                }
-            ],
-        }],
-        [{
-            "envs": [
-                {
-                    "name": "first",
-                    "value": "True",
-                },
-                {
-                    "name": "second",
-                    "value": "True",
-                }
-            ],
-        }],
+        [
+            {
+                "envs": [
+                    {
+                        "name": "first",
+                        "valueFrom": "True",
+                    },
+                    {
+                        "name": "second",
+                        "valueFrom": "False",
+                    },
+                ],
+            }
+        ],
+        [
+            {
+                "envs": [
+                    {
+                        "name": "first",
+                        "value": "True",
+                    },
+                    {
+                        "name": "second",
+                        "value": "True",
+                    },
+                ],
+            }
+        ],
     ],
 )
 def test_value_operations(desired_obj):
@@ -77,24 +83,30 @@ def test_value_operations(desired_obj):
 @pytest.mark.parametrize(
     ["desired_obj"],
     [
-        [{
-            "list": [
-                {"name":"container1"},
-                {"name":"container2"},
-                {"name":"container3"},
-            ],
-        }],
-        [{
-            "list": [
-                {"name":"container1"},
-            ],
-        }],
-        [{
-            "list": [
-                {"name":"container1"},
-                {"name":"container_changed"},
-            ],
-        }],
+        [
+            {
+                "list": [
+                    {"name": "container1"},
+                    {"name": "container2"},
+                    {"name": "container3"},
+                ],
+            }
+        ],
+        [
+            {
+                "list": [
+                    {"name": "container1"},
+                ],
+            }
+        ],
+        [
+            {
+                "list": [
+                    {"name": "container1"},
+                    {"name": "container_changed"},
+                ],
+            }
+        ],
     ],
 )
 def test_list_operations(desired_obj):
@@ -109,18 +121,9 @@ def test_list_operations(desired_obj):
 @pytest.mark.parametrize(
     ["desired_obj"],
     [
-        [{
-            "new_value": "patched"
-        }],
-        [{
-            "added_list": [
-                {"new_value"}
-            ]
-        }],
-        [{
-            "original_value": 'patched'
-        }],
-        
+        [{"new_value": "patched"}],
+        [{"added_list": [{"new_value"}]}],
+        [{"original_value": "patched"}],
     ],
 )
 def test_patch_operations(desired_obj):

--- a/tests/deploy_manager/test_replace_utils.py
+++ b/tests/deploy_manager/test_replace_utils.py
@@ -11,7 +11,7 @@ import pytest
 import alog
 
 # Local
-from oper8.deploy_manager.replace_utils import REPLACE_FUNCS, requires_replace
+from oper8.deploy_manager.replace_utils import _REPLACE_FUNCS, requires_replace
 
 ## Helpers #####################################################################
 
@@ -82,7 +82,7 @@ def test_value_operations(desired_obj):
     current_obj = sample_object()
     assert requires_replace(current_obj, desired_obj)
     # Ensure each replace function is still able to be called
-    for func in REPLACE_FUNCS:
+    for func in _REPLACE_FUNCS:
         func(current_obj, desired_obj)
 
 
@@ -149,7 +149,7 @@ def test_list_operations(desired_obj, requires) -> None:
     current_obj = sample_object()
     assert requires_replace(current_obj, desired_obj) == requires
     # Ensure each replace function is still able to be called
-    for func in REPLACE_FUNCS:
+    for func in _REPLACE_FUNCS:
         func(current_obj, desired_obj)
 
 

--- a/tests/deploy_manager/test_replace_utils.py
+++ b/tests/deploy_manager/test_replace_utils.py
@@ -31,6 +31,9 @@ def sample_object():
                 "valueFrom": "False",
             },
         ],
+        "dicts_in_lists": [
+            {"someDict": {"someValue": "onetwo", "other": "threefour"}},
+        ],
         "list": [
             {"name": "container1"},
             {"name": "container2"},
@@ -92,6 +95,23 @@ def test_value_operations(desired_obj):
                     {"name": "container1"},
                     {"name": "container2"},
                     {"name": "container3"},
+                ],
+            },
+            False,
+        ],
+        [
+            {
+                "dicts_in_lists": [
+                    {"someDict": {"someValue": "onetwo", "other": "threefour"}},
+                ],
+            },
+            False,
+        ],
+        [
+            {
+                "dicts_in_lists": [
+                    {"someDict": {"someValue": "onetwo", "other": "threefour"}},
+                    {"appendedDict": {"someValue": "onetwo", "other": "threefour"}},
                 ],
             },
             False,

--- a/tests/deploy_manager/test_replace_utils.py
+++ b/tests/deploy_manager/test_replace_utils.py
@@ -11,7 +11,7 @@ import pytest
 import alog
 
 # Local
-from oper8.deploy_manager.replace_utils import requires_replace
+from oper8.deploy_manager.replace_utils import requires_replace, REPLACE_FUNCS
 
 ## Helpers #####################################################################
 
@@ -78,6 +78,9 @@ def test_value_operations(desired_obj):
     """Test that adding a ref to an object with none present adds as expected"""
     current_obj = sample_object()
     assert requires_replace(current_obj, desired_obj)
+    # Ensure each replace function is still able to be called
+    for func in REPLACE_FUNCS:
+        func(current_obj, desired_obj)
 
 
 @pytest.mark.parametrize(
@@ -113,7 +116,9 @@ def test_list_operations(desired_obj):
     """Test that adding a ref to an object with none present adds as expected"""
     current_obj = sample_object()
     assert requires_replace(current_obj, desired_obj)
-
+    # Ensure each replace function is still able to be called
+    for func in REPLACE_FUNCS:
+        func(current_obj, desired_obj)
 
 ## Patch functions ##################################################################
 

--- a/tests/watch_manager/python_watch_manager/test_reconcile_process_entrypoint.py
+++ b/tests/watch_manager/python_watch_manager/test_reconcile_process_entrypoint.py
@@ -17,6 +17,7 @@ import alog
 
 # Local
 from oper8 import DeployManagerBase
+from oper8.deploy_manager import DeployMethod
 from oper8.deploy_manager.dry_run_deploy_manager import DryRunDeployManager
 from oper8.deploy_manager.kube_event import KubeEventType
 from oper8.reconcile import ReconciliationResult
@@ -98,13 +99,18 @@ def mock_entrypoint_deploy_manager():
     original_deploy = DryRunDeployManager._deploy
 
     def mocked_deploy(
-        self, resource_definitions, call_watches=True, manage_owner_references=True
+        self,
+        resource_definitions,
+        call_watches=True,
+        manage_owner_references=True,
+        method=DeployMethod.DEFAULT,
     ):
         success, changes = original_deploy(
             self,
             resource_definitions=resource_definitions,
             call_watches=call_watches,
             manage_owner_references=manage_owner_references,
+            method=method,
         )
         if not success or not changes:
             log.debug2("Failed to deploy resources")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/IBM/oper8/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## Related Issue
Supports #?

## Related PRs
This PR is not dependent on any other PR

## What this PR does / why we need it
This PR adds support for automatically "replacing" an object with a `PUT` request when a `PATCH` would fail. This affects things like changing envVars from `value` to `valueFrom` and when modifying lists.

This PR also adds support for manually overriding the deploy method used by a resource. This allows a resource to always use `PUT` or `PATCH` regardless of what was changed.

## Special notes for your reviewer

## If applicable**
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

## What gif most accurately describes how I feel towards this PR?
![Example of a gif](https://media.giphy.com/media/snwvCcEKk33Hy/giphy.gif)
