### PR TITLE
Add argument to optionally generate resource version

### DIFF
--- a/oper8/deploy_manager/dry_run_deploy_manager.py
+++ b/oper8/deploy_manager/dry_run_deploy_manager.py
@@ -35,13 +35,14 @@ class DryRunDeployManager(DeployManagerBase):
     Deploy manager which doesn't actually deploy!
     """
 
-    def __init__(self, resources=None, owner_cr=None, strict_resource_version=False):
+    def __init__(self, resources=None, owner_cr=None, strict_resource_version=False, generate_resource_version=True):
         """Construct with a static value to use for whether or not the functions
         should report change.
         """
         self._owner_cr = owner_cr
         self._cluster_content = {}
         self.strict_resource_version = strict_resource_version
+        self.generate_resource_version = generate_resource_version
 
         # Dicts of registered watches and watchers
         self._watches = {}
@@ -469,9 +470,12 @@ class DryRunDeployManager(DeployManagerBase):
                 resource["metadata"]["uid"] = entries.get("metadata", {}).get(
                     "uid", str(uuid.uuid4())
                 )
-                resource["metadata"]["resourceVersion"] = str(
-                    random.randint(1, 1000)
-                ).zfill(5)
+                
+                if self.generate_resource_version:
+                    resource["metadata"]["resourceVersion"] = str(
+                        random.randint(1, 1000)
+                    ).zfill(5)
+
                 # Depending on the deploy method either update or fully replace the object
                 if method == DeployMethod.DEFAULT or method == DeployMethod.REPLACE:
                     entries[name] = resource

--- a/oper8/deploy_manager/dry_run_deploy_manager.py
+++ b/oper8/deploy_manager/dry_run_deploy_manager.py
@@ -3,6 +3,7 @@ The DryRunDeployManager implements the DeployManager interface but does not
 actually interact with the cluster and instead holds the state of the cluster in
 a local map.
 """
+
 # Standard
 from datetime import datetime, timedelta
 from functools import partial
@@ -35,7 +36,13 @@ class DryRunDeployManager(DeployManagerBase):
     Deploy manager which doesn't actually deploy!
     """
 
-    def __init__(self, resources=None, owner_cr=None, strict_resource_version=False, generate_resource_version=True):
+    def __init__(
+        self,
+        resources=None,
+        owner_cr=None,
+        strict_resource_version=False,
+        generate_resource_version=True,
+    ):
         """Construct with a static value to use for whether or not the functions
         should report change.
         """
@@ -470,7 +477,7 @@ class DryRunDeployManager(DeployManagerBase):
                 resource["metadata"]["uid"] = entries.get("metadata", {}).get(
                     "uid", str(uuid.uuid4())
                 )
-                
+
                 if self.generate_resource_version:
                     resource["metadata"]["resourceVersion"] = str(
                         random.randint(1, 1000)

--- a/oper8/test_helpers/helpers.py
+++ b/oper8/test_helpers/helpers.py
@@ -231,7 +231,9 @@ class MockDeployManager(DryRunDeployManager):
 
         for resource in resources:
             resource.setdefault("apiVersion", "v1")
-        super().__init__(resources, generate_resource_version=generate_resource_version, **kwargs)
+        super().__init__(
+            resources, generate_resource_version=generate_resource_version, **kwargs
+        )
 
         self.deploy_fail = "assert" if deploy_raise else deploy_fail
         self.disable_fail = "assert" if disable_raise else disable_fail

--- a/oper8/test_helpers/helpers.py
+++ b/oper8/test_helpers/helpers.py
@@ -209,6 +209,7 @@ class MockDeployManager(DryRunDeployManager):
         disable_raise=False,
         get_state_fail=False,
         get_state_raise=False,
+        generate_resource_version=True,
         set_status_fail=False,
         set_status_raise=False,
         auto_enable=True,
@@ -230,7 +231,7 @@ class MockDeployManager(DryRunDeployManager):
 
         for resource in resources:
             resource.setdefault("apiVersion", "v1")
-        super().__init__(resources, **kwargs)
+        super().__init__(resources, generate_resource_version=generate_resource_version, **kwargs)
 
         self.deploy_fail = "assert" if deploy_raise else deploy_fail
         self.disable_fail = "assert" if disable_raise else disable_fail


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/IBM/oper8/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## Related Issue
Supports #ISSUE_NUMBER

## Related PRs
This PR is not dependent on any other PR

## What this PR does / why we need it
This PR adds an argument to `DryRunDeployManager` to optionally generate resource version. 
The resource version is generated with a random value, which may cause errors during unit testing.


## Special notes for your reviewer

## If applicable**
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

## What gif most accurately describes how I feel towards this PR?
![Example of a gif](https://media.giphy.com/media/snwvCcEKk33Hy/giphy.gif)
