### PR TITLE
Use replace_resource only if resource already exists

### DIFF
--- a/oper8/deploy_manager/openshift_deploy_manager.py
+++ b/oper8/deploy_manager/openshift_deploy_manager.py
@@ -920,8 +920,10 @@ class OpenshiftDeployManager(DeployManagerBase):
             # If the resource requires a replace operation then use put. Otherwise use
             # server side apply
             if (
-                req_replace or method is DeployMethod.REPLACE
-            ) and method != DeployMethod.UPDATE:
+                (req_replace or method is DeployMethod.REPLACE)
+                and method != DeployMethod.UPDATE
+                and current != {}
+            ):
                 apply_res = self._replace_resource(
                     resource_definition,
                 )

--- a/oper8/test_helpers/kub_mock.py
+++ b/oper8/test_helpers/kub_mock.py
@@ -791,9 +791,9 @@ class MockKubClient(kubernetes.client.ApiClient):
             content.update({"status": body.get("status", {})})
             updated_content = content
         else:
-            if "status" in content:
-                del content["status"]
-            updated_content = content
+            if "status" in body:
+                del body["status"]
+            updated_content = body
         log.debug3(
             "Updating [%s/%s/%s/%s] with body: %s",
             namespace,
@@ -832,6 +832,7 @@ class MockKubClient(kubernetes.client.ApiClient):
             name=name,
         )
         log.debug3("Current Content: %s", content)
+        log.debug3("Update body: %s", body)
 
         # If the content has a status code, unpack it
         status_code = 200

--- a/tests/deploy_manager/test_openshift_deploy_manager.py
+++ b/tests/deploy_manager/test_openshift_deploy_manager.py
@@ -238,7 +238,8 @@ def test_deploy_method_resource():
     assert len(replace_called) == 0 and len(apply_called) == 1
 
     success, changed = dm.deploy(
-        resource_definitions=[replace_apply_resource], method=DeployMethod.REPLACE,
+        resource_definitions=[replace_apply_resource], 
+        method=DeployMethod.REPLACE,
     )
     assert success
     assert changed

--- a/tests/deploy_manager/test_openshift_deploy_manager.py
+++ b/tests/deploy_manager/test_openshift_deploy_manager.py
@@ -222,6 +222,15 @@ def test_deploy_method_resource():
 
     dm._apply_resource = track_apply
 
+    # Use apply instead of replace when first deploying
+    success, changed = dm.deploy(
+        resource_definitions=make_obj_states(end_cluster_state),
+        method=DeployMethod.REPLACE,
+    )
+    assert success
+    assert changed
+    assert len(replace_called) == 0 and len(apply_called) == 1
+
     success, changed = dm.deploy(
         resource_definitions=make_obj_states(end_cluster_state),
         method=DeployMethod.REPLACE,

--- a/tests/deploy_manager/test_openshift_deploy_manager.py
+++ b/tests/deploy_manager/test_openshift_deploy_manager.py
@@ -197,11 +197,17 @@ def test_deploy_method_resource():
     """
     start_cluster_state = {"test": {"Foo": {"foo.bar.com/v1": {}}}}
     end_cluster_state = {"test": {"Foo": {"foo.bar.com/v1": {"bar": {}}}}}
+    replace_apply_resource = {
+        "kind": "Foo",
+        "apiVersion": "foo.bar.com/v1",
+        "metadata": {"name": "bar", "namespace": "test"},
+        "spec": {"some": "key_1"},
+    }
     end_apply_resource = {
         "kind": "Foo",
         "apiVersion": "foo.bar.com/v1",
         "metadata": {"name": "bar", "namespace": "test"},
-        "spec": {"some": "key"},
+        "spec": {"some": "key_2"},
     }
     dm = setup_testable_manager(cluster_state=start_cluster_state)
     dm._requires_replace = lambda *args, **kwargs: True
@@ -232,19 +238,18 @@ def test_deploy_method_resource():
     assert len(replace_called) == 0 and len(apply_called) == 1
 
     success, changed = dm.deploy(
-        resource_definitions=make_obj_states(end_cluster_state),
-        method=DeployMethod.REPLACE,
+        resource_definitions=[replace_apply_resource], method=DeployMethod.REPLACE,
     )
     assert success
     assert changed
-    assert len(replace_called) == 1 and len(apply_called) == 0
+    assert len(replace_called) == 1 and len(apply_called) == 1
 
     success, changed = dm.deploy(
         resource_definitions=[end_apply_resource], method=DeployMethod.UPDATE
     )
     assert success
     assert changed
-    assert len(replace_called) == 1 and len(apply_called) == 1
+    assert len(replace_called) == 1 and len(apply_called) == 2
 
 
 def test_deploy_method_update_resource():

--- a/tests/deploy_manager/test_openshift_deploy_manager.py
+++ b/tests/deploy_manager/test_openshift_deploy_manager.py
@@ -238,7 +238,7 @@ def test_deploy_method_resource():
     assert len(replace_called) == 0 and len(apply_called) == 1
 
     success, changed = dm.deploy(
-        resource_definitions=[replace_apply_resource], 
+        resource_definitions=[replace_apply_resource],
         method=DeployMethod.REPLACE,
     )
     assert success


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/IBM/oper8/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## Related Issue
Supports #ISSUE_NUMBER

## Related PRs
This PR is not dependent on any other PR

## What this PR does / why we need it
Encountering a 404 error when user uses `_replace_resource` option to deploy a resource that is not currently in the environment.
I would like to add logic to use `_apply_resource` instead of `_replace_resource` when first deploying.

## Special notes for your reviewer

## If applicable**
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

## What gif most accurately describes how I feel towards this PR?
![Example of a gif](https://media.giphy.com/media/snwvCcEKk33Hy/giphy.gif)
