### PR TITLE
Forcably exit when watch thread fails

### DIFF
--- a/oper8/watch_manager/python_watch_manager/threads/watch.py
+++ b/oper8/watch_manager/python_watch_manager/threads/watch.py
@@ -6,7 +6,7 @@ from threading import Lock
 from typing import Dict, List, Optional, Set
 import copy
 import dataclasses
-import sys
+import os
 
 # Third Party
 from kubernetes import watch
@@ -181,7 +181,7 @@ class WatchThread(ThreadBase):  # pylint: disable=too-many-instance-attributes
                         "Unable to start watch within %d attempts",
                         config.python_watch_manager.watch_retry_count,
                     )
-                    sys.exit(1)
+                    os._exit(1)
 
                 if not self.wait_on_precondition(self.retry_delay.total_seconds()):
                     log.debug(

--- a/tests/watch_manager/python_watch_manager/threads/test_watch_thread.py
+++ b/tests/watch_manager/python_watch_manager/threads/test_watch_thread.py
@@ -407,7 +407,7 @@ def test_watch_thread_invalid_rbac():
     watched_object_id = ResourceId.from_resource(watched_object)
 
     with patch(
-        "oper8.watch_manager.python_watch_manager.threads.watch.sys.exit",
+        "oper8.watch_manager.python_watch_manager.threads.watch.os._exit",
         side_effect=Exception("EndTest"),
     ) as exit_mock, library_config(
         python_watch_manager={


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/IBM/oper8/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## Related Issue
Supports #ISSUE_NUMBER

## Related PRs
This PR is not dependent on any other PR

## What this PR does / why we need it
This PR fixes a bug where we used sys.exit(1) which only raises an exception but we wanted os._exit(1) which forcibly exits

## Special notes for your reviewer

## If applicable**
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

## What gif most accurately describes how I feel towards this PR?
![Example of a gif](https://media.giphy.com/media/snwvCcEKk33Hy/giphy.gif)
