### PR TITLE
Rollout callbacks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,71 @@ If the contributed code is not third-party code and you are the author we strong
 
 Please make sure to read and observe our [Code of Conduct](./CODE_OF_CONDUCT.md).
 
+# Development environment setup
+
+## Git setup
+
+First, fork the repository & clone it.
+
+Open the cloned repository, and add [the original repository](https://github.com/IBM/oper8) as the upstream.
+
+```bash
+git remote add upstream git@github.com:IBM/oper8.git
+```
+
+Make sure that your forked repository is up-to-date compared to the original repository.
+
+```bash
+git fetch upstream
+```
+
+Merge the latest upstream into your forked main branch if needed.
+
+```bash
+git merge upstream/main
+```
+
+Once you have the latest code, create a new branch from it and write your codes.
+
+```bash
+git checkout -b <branch_name>
+```
+
+## Python setup
+
+This repository uses [tox](https://tox.wiki/en/latest/index.html) to manage the python development environment. To setup the environment, run the following commands.
+
+Install `tox`.
+
+```bash
+pip install tox
+```
+
+Run `tox` to create a virtual environment based on `tox.ini`.
+
+```bash
+tox
+```
+
+To run tests written in `tests` directory, run `tox -e py<version>`. For example,
+
+```bash
+# Run tests with python 3.12.
+tox -e py312
+```
+
+To only test the specific file such as `tests/test_rollout_manager.py`,
+
+```bash
+tox -e py312 -- tests/test_rollout_manager.py
+```
+
+To format and lint the codes,
+
+```bash
+tox -e fmt,lint
+```
+
 # Your First Contribution
 
 Would you like to help drive the community forward? We will help you understand the organization of the project and direct you to the best places to get started. You'll be able to pick up issues, write code to fix them, and get your work reviewed and merged.

--- a/oper8/controller.py
+++ b/oper8/controller.py
@@ -168,6 +168,22 @@ class Controller(abc.ABC):
         """
         return True
 
+    def after_deploy_unsuccessful(self, session: Session) -> bool:
+        """This allows children to inject logic that will run when the
+        controller has failed or could not finish deploying all components.
+        The default behavior is a no-op.
+
+        Args:
+            session:  Session
+                The current reconciliation session
+
+        Returns:
+            success:  bool
+                True if custom hook code executed successfully and lifecycle
+                should continue
+        """
+        return True
+
     def after_verify(
         self,
         session: Session,  # pylint: disable=unused-argument

--- a/oper8/controller.py
+++ b/oper8/controller.py
@@ -211,6 +211,8 @@ class Controller(abc.ABC):
         Args:
             session:  Session
                 The current reconciliation session
+            failed:  bool
+                Indicator of whether or not the termination was a failure
 
         Returns:
             success:  bool

--- a/oper8/controller.py
+++ b/oper8/controller.py
@@ -203,7 +203,7 @@ class Controller(abc.ABC):
         """
         return True
 
-    def after_verify_unsuccessful(self, session: Session) -> bool:
+    def after_verify_unsuccessful(self, session: Session, failed: bool) -> bool:
         """This allows children to inject logic that will run when the
         controller has finished deploying all components but failed to verify.
         The default behavior is a no-op.

--- a/oper8/controller.py
+++ b/oper8/controller.py
@@ -168,7 +168,7 @@ class Controller(abc.ABC):
         """
         return True
 
-    def after_deploy_unsuccessful(self, session: Session) -> bool:
+    def after_deploy_unsuccessful(self, session: Session, failed: bool) -> bool:
         """This allows children to inject logic that will run when the
         controller has failed or could not finish deploying all components.
         The default behavior is a no-op.

--- a/oper8/controller.py
+++ b/oper8/controller.py
@@ -203,6 +203,22 @@ class Controller(abc.ABC):
         """
         return True
 
+    def after_verify_unsuccessful(self, session: Session) -> bool:
+        """This allows children to inject logic that will run when the
+        controller has finished deploying all components but failed to verify.
+        The default behavior is a no-op.
+
+        Args:
+            session:  Session
+                The current reconciliation session
+
+        Returns:
+            success:  bool
+                True if custom hook code executed successfully and lifecycle
+                should continue
+        """
+        return True
+
     def should_requeue(self, session: Session) -> Tuple[bool, Optional[RequeueParams]]:
         """should_requeue determines if current reconcile request should be re-queued.
 

--- a/oper8/controller.py
+++ b/oper8/controller.py
@@ -176,6 +176,8 @@ class Controller(abc.ABC):
         Args:
             session:  Session
                 The current reconciliation session
+            failed:  bool
+                Indicator of whether or not the termination was a failure
 
         Returns:
             success:  bool

--- a/oper8/rollout_manager.py
+++ b/oper8/rollout_manager.py
@@ -436,7 +436,7 @@ class RolloutManager:
             log.debug("Running after-verify-unsuccessful")
             try:
                 is_after_verify_unsuccessful_completed = (
-                    self._after_verify_unsuccessful(self._session)
+                    self._after_verify_unsuccessful(self._session, phase3_failed)
                 )
                 if not is_after_verify_unsuccessful_completed:
                     phase4_exception = VerificationError(

--- a/oper8/rollout_manager.py
+++ b/oper8/rollout_manager.py
@@ -431,7 +431,7 @@ class RolloutManager:
 
         # If deployment is completed, but verification is not, run _after_verify_unsuccessful.
         if (
-            phase1_complete and not phase3_complete
+            phase1_complete and phase2_complete and not phase3_complete
         ) and self._after_verify_unsuccessful:
             log.debug("Running after-verify-unsuccessful")
             try:

--- a/oper8/rollout_manager.py
+++ b/oper8/rollout_manager.py
@@ -326,7 +326,7 @@ class RolloutManager:
             log.debug2("Running after-deploy-unsuccessful")
             try:
                 is_after_deploy_unsuccessful_completed = (
-                    self._after_deploy_unsuccessful(self._session)
+                    self._after_deploy_unsuccessful(self._session, phase1_failed)
                 )
                 if not is_after_deploy_unsuccessful_completed:
                     phase2_exception = VerificationError(

--- a/oper8/status.py
+++ b/oper8/status.py
@@ -160,7 +160,7 @@ def make_application_status(  # pylint: disable=too-many-arguments,too-many-loca
         operator_version:  Optional[str]
             The operator version for this application
         kind: Optional[str]
-            The kind of reconciliing CR. If specified, this function adds
+            The kind of reconciling CR. If specified, this function adds
             service status field which is compliant with IBM Cloud Pak
             requirements.
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -4,9 +4,9 @@ set -e
 BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$BASE_DIR"
 
+pytest_opts=("$@")
 allow_warnings=${ALLOW_WARNINGS:-"0"}
-if [ "$allow_warnings" = "1" ]
-then
+if [ "$allow_warnings" = "1" ]; then
     warn_arg=""
 else
     # NOTE: The AnsibleWatchManager raises an ImportWarning when ansible imports
@@ -15,16 +15,21 @@ else
 
     # If running with 3.12 or later, some of the dependencies use deprecated
     # functionality
-    if [ "$(python --version | cut -d' ' -f 2 | cut -d'.' -f 2)" -gt "11" ]
-    then
+    if [ "$(python --version | cut -d' ' -f 2 | cut -d'.' -f 2)" -gt "11" ]; then
         warn_arg="$warn_arg -W ignore::DeprecationWarning"
     fi
 fi
 
+# Show the test coverage when running the whole test, otherwise omit.
+if [[ "${pytest_opts[*]}" != *"tests/"* ]]; then
+    pytest_opts+=(
+        --cov-config=.coveragerc
+        --cov=oper8
+        --cov-report=term
+        --cov-report=html
+        --cov-fail-under=85.00
+    )
+fi
+
 PYTHONPATH="${BASE_DIR}:$PYTHONPATH" python3 -m pytest \
-    --cov-config=.coveragerc \
-    --cov=oper8 \
-    --cov-report=term \
-    --cov-report=html \
-    --cov-fail-under=85.00 \
-    $warn_arg "$@"
+    $warn_arg "${pytest_opts[@]}"

--- a/tests/test_rollout_manager.py
+++ b/tests/test_rollout_manager.py
@@ -315,8 +315,17 @@ class TestRolloutManager:
         for i, comp in enumerate(comps[1:]):
             session.add_component_dependency(comp, comps[i])
 
+        after_deploy = mock.Mock(return_value=True)
+        after_deploy_unsuccessful = mock.Mock(return_value=True)
+        after_verify = mock.Mock(return_value=True)
+
         # Create the rollout manager and run the rollout
-        mgr = RolloutManager(session)
+        mgr = RolloutManager(
+            session,
+            after_deploy=after_deploy,
+            after_deploy_unsuccessful=after_deploy_unsuccessful,
+            after_verify=after_verify,
+        )
         completion_state = mgr.rollout()
         assert completion_state.deploy_completed()
         assert not completion_state.verify_completed()
@@ -330,6 +339,11 @@ class TestRolloutManager:
         assert comp_a.verify_completed()
         assert not comp_b.verify_completed()
         assert not comp_c.verify_completed()
+
+        # Check the callbacks.
+        assert after_deploy.called
+        assert not after_deploy_unsuccessful.called
+        assert not after_verify.called
 
         # Make sure the completion state looks right
         assert completion_state == CompletionState(

--- a/tests/test_rollout_manager.py
+++ b/tests/test_rollout_manager.py
@@ -323,6 +323,7 @@ class TestRolloutManager:
         after_deploy = mock.Mock(return_value=True)
         after_deploy_unsuccessful = mock.Mock(return_value=True)
         after_verify = mock.Mock(return_value=True)
+        after_verify_unsuccessful = mock.Mock(return_value=True)
 
         # Create the rollout manager and run the rollout
         mgr = RolloutManager(
@@ -330,6 +331,7 @@ class TestRolloutManager:
             after_deploy=after_deploy,
             after_deploy_unsuccessful=after_deploy_unsuccessful,
             after_verify=after_verify,
+            after_verify_unsuccessful=after_verify_unsuccessful,
         )
         completion_state = mgr.rollout()
         assert completion_state.deploy_completed()
@@ -349,6 +351,7 @@ class TestRolloutManager:
         assert after_deploy.called
         assert not after_deploy_unsuccessful.called
         assert not after_verify.called
+        assert after_verify_unsuccessful.called
 
         # Make sure the completion state looks right
         assert completion_state == CompletionState(

--- a/tests/test_rollout_manager.py
+++ b/tests/test_rollout_manager.py
@@ -257,7 +257,7 @@ class TestRolloutManager:
         assert not comp_c.deploy_completed()
         assert not comp_c.verify_completed()
 
-    def test_failed_deploy_callbacks(self):
+    def test_rollout_deploy_incomplete(self):
         """Test the correct after_deploy, after_deploy_unsuccessful, after_verify,
         and after_verify_unsuccessful hooks are executed when deploy is incomplete."""
         session = setup_session()
@@ -274,10 +274,10 @@ class TestRolloutManager:
             session.add_component_dependency(comp, comps[i])
 
         # Setup callbacks.
-        # TODO add after verify unsuccessful callback.
         after_deploy = mock.Mock(return_value=True)
         after_deploy_unsuccessful = mock.Mock(return_value=True)
         after_verify = mock.Mock(return_value=True)
+        after_verify_unsuccessful = mock.Mock(return_value=True)
 
         # Create the rollout manager and run the rollout
         mgr = RolloutManager(
@@ -285,6 +285,7 @@ class TestRolloutManager:
             after_deploy=after_deploy,
             after_deploy_unsuccessful=after_deploy_unsuccessful,
             after_verify=after_verify,
+            after_verify_unsuccessful=after_verify_unsuccessful,
         )
         mgr.rollout()
 
@@ -300,6 +301,7 @@ class TestRolloutManager:
         assert not after_deploy.called
         assert after_deploy_unsuccessful.called
         assert not after_verify.called
+        assert not after_verify_unsuccessful.called
 
     def test_rollout_verify_incomplete(self):
         """Test that a failed verify test is handled properly as not a failure,

--- a/tests/test_rollout_manager.py
+++ b/tests/test_rollout_manager.py
@@ -486,14 +486,31 @@ class TestRolloutManager:
 
         session = setup_session()
         comp = DummyRolloutComponent("A")(session)
+
         after_deploy = mock.Mock(side_effect=fail)
-        mgr = RolloutManager(session, after_deploy=after_deploy)
+        after_deploy_unsuccessful = mock.Mock(return_value=True)
+        after_verify = mock.Mock(return_value=True)
+        after_verify_unsuccessful = mock.Mock(return_value=True)
+
+        mgr = RolloutManager(
+            session,
+            after_deploy=after_deploy,
+            after_deploy_unsuccessful=after_deploy_unsuccessful,
+            after_verify=after_verify,
+            after_verify_unsuccessful=after_verify_unsuccessful,
+        )
+
         completion_state = mgr.rollout()
         log.debug2(completion_state)
         assert completion_state.deploy_completed()
         assert not completion_state.verify_completed()
         assert completion_state.failed()
+
         assert after_deploy.called
+        assert not after_deploy_unsuccessful.called
+        assert not after_verify.called
+        assert not after_verify_unsuccessful.called
+
         assert isinstance(completion_state.exception, RuntimeError)
 
     def test_after_deploy_fatal_error(self):
@@ -506,14 +523,31 @@ class TestRolloutManager:
 
         session = setup_session()
         comp = DummyRolloutComponent("A")(session)
+
         after_deploy = mock.Mock(side_effect=fail)
-        mgr = RolloutManager(session, after_deploy=after_deploy)
+        after_deploy_unsuccessful = mock.Mock(return_value=True)
+        after_verify = mock.Mock(return_value=True)
+        after_verify_unsuccessful = mock.Mock(return_value=True)
+
+        mgr = RolloutManager(
+            session,
+            after_deploy=after_deploy,
+            after_deploy_unsuccessful=after_deploy_unsuccessful,
+            after_verify=after_verify,
+            after_verify_unsuccessful=after_verify_unsuccessful,
+        )
+
         completion_state = mgr.rollout()
         log.debug2(completion_state)
         assert completion_state.deploy_completed()
         assert not completion_state.verify_completed()
         assert completion_state.failed()
+
         assert after_deploy.called
+        assert not after_deploy_unsuccessful.called
+        assert not after_verify.called
+        assert not after_verify_unsuccessful.called
+
         assert isinstance(completion_state.exception, ClusterError)
 
     def test_after_deploy_non_fatal_error(self):
@@ -526,14 +560,31 @@ class TestRolloutManager:
 
         session = setup_session()
         comp = DummyRolloutComponent("A")(session)
+
         after_deploy = mock.Mock(side_effect=fail)
-        mgr = RolloutManager(session, after_deploy=after_deploy)
+        after_deploy_unsuccessful = mock.Mock(return_value=True)
+        after_verify = mock.Mock(return_value=True)
+        after_verify_unsuccessful = mock.Mock(return_value=True)
+
+        mgr = RolloutManager(
+            session,
+            after_deploy=after_deploy,
+            after_deploy_unsuccessful=after_deploy_unsuccessful,
+            after_verify=after_verify,
+            after_verify_unsuccessful=after_verify_unsuccessful,
+        )
+
         completion_state = mgr.rollout()
         log.debug2(completion_state)
         assert completion_state.deploy_completed()
         assert not completion_state.verify_completed()
         assert not completion_state.failed()
+
         assert after_deploy.called
+        assert not after_deploy_unsuccessful.called
+        assert not after_verify.called
+        assert not after_verify_unsuccessful.called
+
         assert isinstance(completion_state.exception, PreconditionError)
 
     def test_after_verify_false(self):
@@ -542,14 +593,31 @@ class TestRolloutManager:
         """
         session = setup_session()
         comp = DummyRolloutComponent("A")(session)
+
+        after_deploy = mock.Mock(return_value=True)
+        after_deploy_unsuccessful = mock.Mock(return_value=True)
         after_verify = mock.Mock(return_value=False)
-        mgr = RolloutManager(session, after_verify=after_verify)
+        after_verify_unsuccessful = mock.Mock(return_value=True)
+
+        mgr = RolloutManager(
+            session,
+            after_deploy=after_deploy,
+            after_deploy_unsuccessful=after_deploy_unsuccessful,
+            after_verify=after_verify,
+            after_verify_unsuccessful=after_verify_unsuccessful,
+        )
+
         completion_state = mgr.rollout()
         log.debug2(completion_state)
         assert completion_state.deploy_completed()
         assert not completion_state.verify_completed()
         assert not completion_state.failed()
+
+        assert after_deploy.called
+        assert not after_deploy_unsuccessful.called
         assert after_verify.called
+        assert not after_verify_unsuccessful.called
+
         assert isinstance(completion_state.exception, VerificationError)
 
     def test_after_verify_non_oper8_error(self):
@@ -562,14 +630,31 @@ class TestRolloutManager:
 
         session = setup_session()
         comp = DummyRolloutComponent("A")(session)
+
+        after_deploy = mock.Mock(return_value=True)
+        after_deploy_unsuccessful = mock.Mock(return_value=True)
         after_verify = mock.Mock(side_effect=fail)
-        mgr = RolloutManager(session, after_verify=after_verify)
+        after_verify_unsuccessful = mock.Mock(return_value=True)
+
+        mgr = RolloutManager(
+            session,
+            after_deploy=after_deploy,
+            after_deploy_unsuccessful=after_deploy_unsuccessful,
+            after_verify=after_verify,
+            after_verify_unsuccessful=after_verify_unsuccessful,
+        )
+
         completion_state = mgr.rollout()
         log.debug2(completion_state)
         assert completion_state.deploy_completed()
         assert not completion_state.verify_completed()
         assert completion_state.failed()
+
+        assert after_deploy.called
+        assert not after_deploy_unsuccessful.called
         assert after_verify.called
+        assert not after_verify_unsuccessful.called
+
         assert isinstance(completion_state.exception, RuntimeError)
 
     def test_after_verify_fatal_error(self):
@@ -582,14 +667,30 @@ class TestRolloutManager:
 
         session = setup_session()
         comp = DummyRolloutComponent("A")(session)
+
+        after_deploy = mock.Mock(return_value=True)
+        after_deploy_unsuccessful = mock.Mock(return_value=True)
         after_verify = mock.Mock(side_effect=fail)
-        mgr = RolloutManager(session, after_verify=after_verify)
+        after_verify_unsuccessful = mock.Mock(return_value=True)
+
+        mgr = RolloutManager(
+            session,
+            after_deploy=after_deploy,
+            after_deploy_unsuccessful=after_deploy_unsuccessful,
+            after_verify=after_verify,
+            after_verify_unsuccessful=after_verify_unsuccessful,
+        )
         completion_state = mgr.rollout()
         log.debug2(completion_state)
         assert completion_state.deploy_completed()
         assert not completion_state.verify_completed()
         assert completion_state.failed()
+
+        assert after_deploy.called
+        assert not after_deploy_unsuccessful.called
         assert after_verify.called
+        assert not after_verify_unsuccessful.called
+
         assert isinstance(completion_state.exception, ClusterError)
 
     def test_after_verify_non_fatal_error(self):
@@ -602,12 +703,29 @@ class TestRolloutManager:
 
         session = setup_session()
         comp = DummyRolloutComponent("A")(session)
+
+        after_deploy = mock.Mock(return_value=True)
+        after_deploy_unsuccessful = mock.Mock(return_value=True)
         after_verify = mock.Mock(side_effect=fail)
-        mgr = RolloutManager(session, after_verify=after_verify)
+        after_verify_unsuccessful = mock.Mock(return_value=True)
+
+        mgr = RolloutManager(
+            session,
+            after_deploy=after_deploy,
+            after_deploy_unsuccessful=after_deploy_unsuccessful,
+            after_verify=after_verify,
+            after_verify_unsuccessful=after_verify_unsuccessful,
+        )
+
         completion_state = mgr.rollout()
         log.debug2(completion_state)
         assert completion_state.deploy_completed()
         assert not completion_state.verify_completed()
         assert not completion_state.failed()
+
+        assert after_deploy.called
+        assert not after_deploy_unsuccessful.called
         assert after_verify.called
+        assert not after_verify_unsuccessful.called
+
         assert isinstance(completion_state.exception, PreconditionError)

--- a/tests/test_rollout_manager.py
+++ b/tests/test_rollout_manager.py
@@ -201,13 +201,15 @@ class TestRolloutManager:
 
         # Create the rollout manager and run the rollout
         after_deploy = mock.Mock(return_value=True)
-        after_verify = mock.Mock(return_value=True)
         after_deploy_unsuccessful = mock.Mock(return_value=True)
+        after_verify = mock.Mock(return_value=True)
+        after_verify_unsuccessful = mock.Mock(return_value=True)
         mgr = RolloutManager(
             session,
             after_deploy=after_deploy,
-            after_verify=after_verify,
             after_deploy_unsuccessful=after_deploy_unsuccessful,
+            after_verify=after_verify,
+            after_verify_unsuccessful=after_verify_unsuccessful,
         )
         completion_state = mgr.rollout()
         log.debug2(completion_state)
@@ -222,6 +224,7 @@ class TestRolloutManager:
         assert after_deploy.called
         assert not after_deploy_unsuccessful.called
         assert after_verify.called
+        assert not after_verify_unsuccessful.called
 
     #####################
     ## Rollout Failure ##

--- a/tests/test_rollout_manager.py
+++ b/tests/test_rollout_manager.py
@@ -202,8 +202,12 @@ class TestRolloutManager:
         # Create the rollout manager and run the rollout
         after_deploy = mock.Mock(return_value=True)
         after_verify = mock.Mock(return_value=True)
+        after_deploy_unsuccessful = mock.Mock(return_value=True)
         mgr = RolloutManager(
-            session, after_deploy=after_deploy, after_verify=after_verify
+            session,
+            after_deploy=after_deploy,
+            after_verify=after_verify,
+            after_deploy_unsuccessful=after_deploy_unsuccessful,
         )
         completion_state = mgr.rollout()
         log.debug2(completion_state)
@@ -212,8 +216,11 @@ class TestRolloutManager:
         # forward states
         assert completion_state.deploy_completed()
         assert completion_state.verify_completed()
+
+        # Check callbacks.
         assert not completion_state.failed()
         assert after_deploy.called
+        assert not after_deploy_unsuccessful.called
         assert after_verify.called
 
     #####################

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ passenv =
     LOG_JSON
     LOG_THREAD_ID
     LOG_CHANNEL_WIDTH
-commands = ./scripts/run_tests.sh
+commands = ./scripts/run_tests.sh {posargs}
 allowlist_externals = ./scripts/run_tests.sh
 
 ; Unclear: We probably want to test wheel packaging


### PR DESCRIPTION
## Related Issue

closes #129

## Related PRs

This PR is not dependent on any other PR
## What this PR does / why we need it

`why we need it` > please check https://github.com/IBM/oper8/issues/129.

`what this PR does`:
- Added two callbacks, `after_deploy_unsuccessful` and `after_verify_unsuccessful`. They are executed at [Rollout.rollout](https://github.com/IBM/oper8/compare/main...yuki462-b:rollout-callbacks?expand=1#diff-fab88ac3bcb33457972b94f4b89a3fdb64b1ba7bfdb3a686db262cd1c705f447L235) depending on the deployment/verification results.
- Added tests for those new two callbacks at `tests/test_rollout_manager.py`
- Added development environment setup instructions at `CONTRIBUTING.md`
- Updated `tox.ini` and `scripts/run_tests.sh` to only execute the part of the tests when needed. (Test commands are described at `CONTRIBUTING.md`)

Details:
`after_deploy_unsuccessful` is executed when [Phase 1: Deploy Graph](https://github.com/IBM/oper8/compare/main...yuki462-b:rollout-callbacks?expand=1#diff-fab88ac3bcb33457972b94f4b89a3fdb64b1ba7bfdb3a686db262cd1c705f447L277) is not completed. `after_verify_unsuccessful` is executed when Phase1 and [Phase2](https://github.com/IBM/oper8/compare/main...yuki462-b:rollout-callbacks?expand=1#diff-fab88ac3bcb33457972b94f4b89a3fdb64b1ba7bfdb3a686db262cd1c705f447R318) are completed but [Phase3](https://github.com/IBM/oper8/compare/main...yuki462-b:rollout-callbacks?expand=1#diff-fab88ac3bcb33457972b94f4b89a3fdb64b1ba7bfdb3a686db262cd1c705f447R368) is not. They could be used when you want to run some callback functions when deployment or verification fails.

Tests:

Verified formatting and linting are passed:
```bash
$ tox -e fmt,lint
...
All checks passed!
  fmt: OK (7.42=setup[2.62]+cmd[4.80] seconds)
  lint: OK (0.98=setup[0.60]+cmd[0.39] seconds)
  congratulations :) (8.54 seconds)
```

Verifies that all tests have been passed:
```bash
$ tox -e py312
```
<details><summary>Detailed test results</summary>

```
======================================================================== test session starts =========================================================================
platform darwin -- Python 3.12.1, pytest-8.3.3, pluggy-1.5.0
cachedir: .tox/py312/.pytest_cache
rootdir: /Users/yuki462/Codes/github-ibm-repos/forked/oper8-yuki462
configfile: pyproject.toml
plugins: cov-5.0.0, timeout-2.3.1
collected 856 items                                                                                                                                                  

tests/dag/test_completion_state.py .                                                                                                                           [  0%]
tests/dag/test_graph.py .........                                                                                                                              [  1%]
tests/dag/test_node.py .........                                                                                                                               [  2%]
tests/dag/test_runner.py ...............                                                                                                                       [  3%]
tests/deploy_manager/test_dry_run_deploy_manager.py ..............................................................                                             [ 11%]
tests/deploy_manager/test_openshift_deploy_manager.py ...............................................................                                          [ 18%]
tests/deploy_manager/test_owner_references.py ..........                                                                                                       [ 19%]
tests/deploy_manager/test_replace_utils.py ...........                                                                                                         [ 21%]
tests/temporary_patch/test_temporary_patch_component.py ..............                                                                                         [ 22%]
tests/temporary_patch/test_temporary_patch_controller.py ..........                                                                                            [ 23%]
tests/test_component.py .................................                                                                                                      [ 27%]
tests/test_config.py .................                                                                                                                         [ 29%]
tests/test_controller.py .........................                                                                                                             [ 32%]
tests/test_decorator.py ....                                                                                                                                   [ 33%]
tests/test_exceptions.py ............                                                                                                                          [ 34%]
tests/test_main.py ..................                                                                                                                          [ 36%]
tests/test_patch.py .....................                                                                                                                      [ 39%]
tests/test_patch_strategic_merge.py .................                                                                                                          [ 41%]
tests/test_reconcile.py ..........................................................................................                                             [ 51%]
tests/test_rollout_manager.py ................                                                                                                                 [ 53%]
tests/test_session.py ........................                                                                                                                 [ 56%]
tests/test_setup_vcs.py ......                                                                                                                                 [ 56%]
tests/test_status.py .............................................                                                                                             [ 62%]
tests/test_utils.py ................                                                                                                                           [ 64%]
tests/test_vcs.py ..................                                                                                                                           [ 66%]
tests/test_verify_resources.py ..............................................                                                                                  [ 71%]
tests/watch_manager/ansible_watch_manager/modules/test_k8s_application.py .............                                                                        [ 73%]
tests/watch_manager/ansible_watch_manager/modules/test_log_rotator.py .                                                                                        [ 73%]
tests/watch_manager/ansible_watch_manager/test_ansible_watch_manager.py ..............                                                                         [ 74%]
tests/watch_manager/python_watch_manager/filters/test_common_filters.py ..                                                                                     [ 75%]
tests/watch_manager/python_watch_manager/filters/test_filters.py ..........                                                                                    [ 76%]
tests/watch_manager/python_watch_manager/filters/test_manager.py .......                                                                                       [ 76%]
tests/watch_manager/python_watch_manager/leader_election/test_annotation.py .....                                                                              [ 77%]
tests/watch_manager/python_watch_manager/leader_election/test_init.py ....                                                                                     [ 78%]
tests/watch_manager/python_watch_manager/leader_election/test_lease.py ......                                                                                  [ 78%]
tests/watch_manager/python_watch_manager/leader_election/test_life.py .......                                                                                  [ 79%]
tests/watch_manager/python_watch_manager/test_python_watch_manager.py .....                                                                                    [ 80%]
tests/watch_manager/python_watch_manager/test_reconcile_process_entrypoint.py ...                                                                              [ 80%]
tests/watch_manager/python_watch_manager/threads/test_heartbeat.py ...                                                                                         [ 80%]
tests/watch_manager/python_watch_manager/threads/test_reconcile_thread.py ......                                                                               [ 81%]
tests/watch_manager/python_watch_manager/threads/test_timer_thread.py ..                                                                                       [ 81%]
tests/watch_manager/python_watch_manager/threads/test_watch_thread.py ..........                                                                               [ 82%]
tests/watch_manager/python_watch_manager/utils/test_pwm_util_common.py ..........                                                                              [ 84%]
tests/watch_manager/test_dry_run_watch_manager.py .....                                                                                                        [ 84%]
tests/watch_manager/test_watch_manager_base.py .....                                                                                                           [ 85%]
tests/x/datastores/cos/test_cos_connection.py ........................                                                                                         [ 88%]
tests/x/datastores/postgres/test_pg_factory.py .                                                                                                               [ 88%]
tests/x/datastores/postgres/test_postgres_connection.py .........................                                                                              [ 91%]
tests/x/datastores/redis/test_redis_connection.py ...........                                                                                                  [ 92%]
tests/x/datastores/redis/test_redis_factory.py ..                                                                                                              [ 92%]
tests/x/datastores/redis/test_redis_interfaces.py .                                                                                                            [ 92%]
tests/x/datastores/test_factory_base.py ...................                                                                                                    [ 94%]
tests/x/utils/test_abc_static.py .....                                                                                                                         [ 95%]
tests/x/utils/test_common.py ..                                                                                                                                [ 95%]
tests/x/utils/test_deps_annotation.py ..................                                                                                                       [ 97%]
tests/x/utils/test_tls.py .                                                                                                                                    [ 98%]
tests/x/utils/test_tls_context.py ............                                                                                                                 [ 99%]
tests/x/utils/tls_context/test_internal.py ....                                                                                                                [ 99%]
tests/x/utils/tls_context/test_tls_preconditions.py .                                                                                                          [100%]

---------- coverage: platform darwin, python 3.12.1-final-0 ----------
Name                                                                       Stmts   Miss  Cover
----------------------------------------------------------------------------------------------
oper8/__init__.py                                                             11      0   100%
oper8/__main__.py                                                             65      0   100%
oper8/_version.py                                                             11     11     0%
oper8/cmd/__init__.py                                                          4      0   100%
oper8/cmd/base.py                                                              8      0   100%
oper8/cmd/check_heartbeat.py                                                  29      0   100%
oper8/cmd/run_operator_cmd.py                                                 90      1    99%
oper8/cmd/setup_vcs_cmd.py                                                    18      1    94%
oper8/component.py                                                           173      0   100%
oper8/config/__init__.py                                                       7      0   100%
oper8/config/config.py                                                         9      0   100%
oper8/config/validation.py                                                   124      0   100%
oper8/constants.py                                                            15      0   100%
oper8/controller.py                                                           94      3    97%
oper8/dag/__init__.py                                                          4      0   100%
oper8/dag/completion_state.py                                                 29      0   100%
oper8/dag/graph.py                                                            52      0   100%
oper8/dag/node.py                                                             94      0   100%
oper8/dag/runner.py                                                          135      0   100%
oper8/decorator.py                                                            19      0   100%
oper8/deploy_manager/__init__.py                                               4      0   100%
oper8/deploy_manager/base.py                                                  21      0   100%
oper8/deploy_manager/dry_run_deploy_manager.py                               282      5    98%
oper8/deploy_manager/kube_event.py                                            15      0   100%
oper8/deploy_manager/openshift_deploy_manager.py                             343     15    96%
oper8/deploy_manager/owner_references.py                                      40      0   100%
oper8/deploy_manager/replace_utils.py                                         59      4    93%
oper8/exceptions.py                                                           35      0   100%
oper8/log_format.py                                                           19      9    53%
oper8/managed_object.py                                                       29      0   100%
oper8/patch.py                                                                37      0   100%
oper8/patch_strategic_merge.py                                                71      0   100%
oper8/reconcile.py                                                           366      1    99%
oper8/rollout_manager.py                                                     148     13    91%
oper8/session.py                                                             154      0   100%
oper8/setup_vcs.py                                                           113      0   100%
oper8/status.py                                                              160      4    98%
oper8/temporary_patch/temporary_patch_component.py                            54      0   100%
oper8/temporary_patch/temporary_patch_controller.py                           36      0   100%
oper8/test_helpers/__init__.py                                                 0      0   100%
oper8/test_helpers/helpers.py                                                339    236    30%
oper8/test_helpers/kub_mock.py                                               409    345    16%
oper8/test_helpers/oper8x_helpers.py                                          22     22     0%
oper8/test_helpers/pwm_helpers.py                                            102    102     0%
oper8/utils.py                                                               113      1    99%
oper8/vcs.py                                                                 129      3    98%
oper8/verify_resources.py                                                     91      0   100%
oper8/version.py                                                               5      5     0%
oper8/watch_manager/__init__.py                                                6      0   100%
oper8/watch_manager/ansible_watch_manager/__init__.py                          1      0   100%
oper8/watch_manager/ansible_watch_manager/ansible_watch_manager.py           128      0   100%
oper8/watch_manager/ansible_watch_manager/modules/k8s_application.py          83      7    92%
oper8/watch_manager/ansible_watch_manager/modules/log_rotator.py               8      0   100%
oper8/watch_manager/base.py                                                   48      3    94%
oper8/watch_manager/dry_run_watch_manager.py                                  47      1    98%
oper8/watch_manager/python_watch_manager/__init__.py                           1      0   100%
oper8/watch_manager/python_watch_manager/filters/__init__.py                   3      0   100%
oper8/watch_manager/python_watch_manager/filters/common.py                    48      3    94%
oper8/watch_manager/python_watch_manager/filters/filters.py                  121      0   100%
oper8/watch_manager/python_watch_manager/filters/manager.py                   76      5    93%
oper8/watch_manager/python_watch_manager/leader_election/__init__.py          17      1    94%
oper8/watch_manager/python_watch_manager/leader_election/annotation.py        60      5    92%
oper8/watch_manager/python_watch_manager/leader_election/base.py              80     11    86%
oper8/watch_manager/python_watch_manager/leader_election/dry_run.py           12      0   100%
oper8/watch_manager/python_watch_manager/leader_election/lease.py             48      3    94%
oper8/watch_manager/python_watch_manager/leader_election/life.py              46      3    93%
oper8/watch_manager/python_watch_manager/python_watch_manager.py              66      7    89%
oper8/watch_manager/python_watch_manager/reconcile_process_entrypoint.py     140     41    71%
oper8/watch_manager/python_watch_manager/threads/__init__.py                   5      0   100%
oper8/watch_manager/python_watch_manager/threads/base.py                      32      1    97%
oper8/watch_manager/python_watch_manager/threads/heartbeat.py                 35      0   100%
oper8/watch_manager/python_watch_manager/threads/reconcile.py                213     23    89%
oper8/watch_manager/python_watch_manager/threads/timer.py                     74      4    95%
oper8/watch_manager/python_watch_manager/threads/watch.py                    169     22    87%
oper8/watch_manager/python_watch_manager/utils/__init__.py                     4      0   100%
oper8/watch_manager/python_watch_manager/utils/common.py                      40      0   100%
oper8/watch_manager/python_watch_manager/utils/constants.py                    5      0   100%
oper8/watch_manager/python_watch_manager/utils/log_handler.py                 27      3    89%
oper8/watch_manager/python_watch_manager/utils/types.py                      112      3    97%
oper8/x/__init__.py                                                            0      0   100%
oper8/x/datastores/__init__.py                                                 6      0   100%
oper8/x/datastores/connection_base.py                                         25      0   100%
oper8/x/datastores/cos/__init__.py                                             2      0   100%
oper8/x/datastores/cos/connection.py                                         111      1    99%
oper8/x/datastores/cos/factory.py                                              5      0   100%
oper8/x/datastores/cos/interfaces.py                                          32     32     0%
oper8/x/datastores/factory_base.py                                           103      0   100%
oper8/x/datastores/interfaces.py                                              19      0   100%
oper8/x/datastores/postgres/__init__.py                                        2      0   100%
oper8/x/datastores/postgres/connection.py                                    107      1    99%
oper8/x/datastores/postgres/factory.py                                         5      0   100%
oper8/x/datastores/postgres/interfaces.py                                      7      7     0%
oper8/x/datastores/redis/__init__.py                                           2      0   100%
oper8/x/datastores/redis/connection.py                                       107      2    98%
oper8/x/datastores/redis/factory.py                                            5      0   100%
oper8/x/datastores/redis/interfaces.py                                        30      1    97%
oper8/x/oper8x_component.py                                                   30      5    83%
oper8/x/utils/__init__.py                                                      0      0   100%
oper8/x/utils/abc_static.py                                                   20      0   100%
oper8/x/utils/common.py                                                       95     14    85%
oper8/x/utils/constants.py                                                     6      0   100%
oper8/x/utils/deps_annotation.py                                             103      0   100%
oper8/x/utils/tls.py                                                          32      1    97%
oper8/x/utils/tls_context/__init__.py                                          2      0   100%
oper8/x/utils/tls_context/factory.py                                          37      0   100%
oper8/x/utils/tls_context/interface.py                                        20      0   100%
oper8/x/utils/tls_context/internal.py                                         87      0   100%
oper8/x/utils/tls_context/public.py                                           11      0   100%
----------------------------------------------------------------------------------------------
TOTAL                                                                       6953    991    86%
Coverage HTML written to dir htmlcov

Required test coverage of 85.0% reached. Total coverage: 85.75%

================================================================== 856 passed in 107.99s (0:01:47) ===================================================================
  py312: OK (112.90=setup[2.46]+cmd[110.43] seconds)
  congratulations :) (113.02 seconds)
```

</details>

## If applicable**
- [x] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

## What gif most accurately describes how I feel towards this PR?

![Example of a gif](https://media1.tenor.com/m/JdA2f-7EkTwAAAAC/elmo-sesame-street.gif)
