### PR TITLE
Using rollout callbacks from controller

### DIFF
--- a/oper8/component.py
+++ b/oper8/component.py
@@ -16,7 +16,7 @@ import alog
 
 # Local
 from . import config
-from .constants import INTERNAL_NAME_ANOTATION_NAME, TEMPORARY_PATCHES_ANNOTATION_NAME
+from .constants import INTERNAL_NAME_ANNOTATION_NAME, TEMPORARY_PATCHES_ANNOTATION_NAME
 from .dag import Graph, Node, ResourceNode
 from .deploy_manager import DeployMethod
 from .exceptions import assert_cluster
@@ -489,11 +489,11 @@ class Component(Node, abc.ABC):
             if config.internal_name_annotation:
                 log.debug2(
                     "Adding internal name annotation [%s: %s]",
-                    INTERNAL_NAME_ANOTATION_NAME,
+                    INTERNAL_NAME_ANNOTATION_NAME,
                     name,
                 )
                 obj.setdefault("metadata", {}).setdefault("annotations", {})[
-                    INTERNAL_NAME_ANOTATION_NAME
+                    INTERNAL_NAME_ANNOTATION_NAME
                 ] = name
 
             # Allow children to inject additional modification logic

--- a/oper8/constants.py
+++ b/oper8/constants.py
@@ -41,7 +41,7 @@ TEMPORARY_PATCHES_ANNOTATION_NAME = "oper8.org/temporary-patches"
 
 # The name of the annotation used to indicate the internal name of each
 # oper8-managed resource
-INTERNAL_NAME_ANOTATION_NAME = "oper8.org/internal-name"
+INTERNAL_NAME_ANNOTATION_NAME = "oper8.org/internal-name"
 
 # Default namespace if none given
 DEFAULT_NAMESPACE = "default"

--- a/oper8/constants.py
+++ b/oper8/constants.py
@@ -42,6 +42,8 @@ TEMPORARY_PATCHES_ANNOTATION_NAME = "oper8.org/temporary-patches"
 # The name of the annotation used to indicate the internal name of each
 # oper8-managed resource
 INTERNAL_NAME_ANNOTATION_NAME = "oper8.org/internal-name"
+# Keeping the misspelled variable for backward compatibility: https://github.com/IBM/oper8/pull/133#discussion_r1820696481
+INTERNAL_NAME_ANOTATION_NAME = INTERNAL_NAME_ANNOTATION_NAME
 
 # Default namespace if none given
 DEFAULT_NAMESPACE = "default"

--- a/oper8/controller.py
+++ b/oper8/controller.py
@@ -356,7 +356,9 @@ class Controller(abc.ABC):
         rollout_manager = RolloutManager(
             session=session,
             after_deploy=self.after_deploy,
+            after_deploy_unsuccessful=self.after_deploy_unsuccessful,
             after_verify=self.after_verify,
+            after_verify_unsuccessful=self.after_verify_unsuccessful,
         )
         completion_state = rollout_manager.rollout()
         rollout_failed = completion_state.failed()

--- a/oper8/test_helpers/helpers.py
+++ b/oper8/test_helpers/helpers.py
@@ -42,9 +42,9 @@ def configure_logging():
     alog.configure(
         os.environ.get("LOG_LEVEL", "off"),
         os.environ.get("LOG_FILTERS", ""),
-        formatter="json"
-        if os.environ.get("LOG_JSON", "").lower() == "true"
-        else "pretty",
+        formatter=(
+            "json" if os.environ.get("LOG_JSON", "").lower() == "true" else "pretty"
+        ),
         thread_id=os.environ.get("LOG_THREAD_ID", "").lower() == "true",
     )
 
@@ -496,7 +496,9 @@ class DummyController(Controller):
         self,
         components=None,
         after_deploy_fail=False,
+        after_deploy_unsuccessful_fail=False,
         after_verify_fail=False,
+        after_verify_unsuccessful_fail=False,
         setup_components_fail=False,
         finalize_components_fail=False,
         should_requeue_fail=False,
@@ -512,7 +514,9 @@ class DummyController(Controller):
 
         # Set up mocks
         self.after_deploy_fail = after_deploy_fail
+        self.after_deploy_unsuccessful_fail = after_deploy_unsuccessful_fail
         self.after_verify_fail = after_verify_fail
+        self.after_verify_unsuccessful_fail = after_verify_unsuccessful_fail
         self.setup_components_fail = setup_components_fail
         self.finalize_components_fail = finalize_components_fail
         self.should_requeue_fail = should_requeue_fail
@@ -521,9 +525,19 @@ class DummyController(Controller):
                 self.after_deploy_fail, super().after_deploy
             )
         )
+        self.after_deploy_unsuccessful = mock.Mock(
+            side_effect=get_failable_method(
+                self.after_deploy_unsuccessful_fail, super().after_deploy_unsuccessful
+            )
+        )
         self.after_verify = mock.Mock(
             side_effect=get_failable_method(
                 self.after_verify_fail, super().after_verify
+            )
+        )
+        self.after_verify_unsuccessful = mock.Mock(
+            side_effect=get_failable_method(
+                self.after_verify_unsuccessful_fail, super().after_verify_unsuccessful
             )
         )
         self.setup_components = mock.Mock(

--- a/oper8/test_helpers/helpers.py
+++ b/oper8/test_helpers/helpers.py
@@ -460,7 +460,7 @@ class MockedOpenshiftDeployManager(OpenshiftDeployManager):
 
 class DummyNodeComponent(DummyComponentBase):
     """
-    Configurable dummy component which will create an abritrary set of
+    Configurable dummy component which will create an arbitrary set of
     resource node instances.
     """
 
@@ -784,7 +784,7 @@ def setup_vcs_project(
                 directory,
                 "commit",
                 "-m",
-                "Annother Commit",
+                "Another Commit",
             ],
             check=True,
         )

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -38,7 +38,7 @@ log = alog.use_channel("TEST")
 
 
 def get_comp_type(name="dummy"):
-    """Paramterization helper to get test both standard and legacy components.
+    """Parametrization helper to get test both standard and legacy components.
     This function also wraps the output class type so that name class attributes
     are not polluted.
     """

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -288,7 +288,7 @@ def test_internal_name_annotation():
         objs = comp.to_config(session)
     assert len(objs) == 1
     assert objs[0].metadata.annotations[
-        constants.INTERNAL_NAME_ANOTATION_NAME
+        constants.INTERNAL_NAME_ANNOTATION_NAME
     ] == ".".join([CompType.name, "bar"])
 
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -363,7 +363,9 @@ def test_after_deploy_failure():
         ctrlr.run_reconcile(session)
 
     assert ctrlr.after_deploy.called
+    assert not ctrlr.after_deploy_unsuccessful.called
     assert not ctrlr.after_verify.called
+    assert not ctrlr.after_verify_unsuccessful.called
 
 
 def test_after_deploy_error():
@@ -375,7 +377,9 @@ def test_after_deploy_error():
 
     # Make sure after_deploy was called, but after_verify was not
     assert ctrlr.after_deploy.called
+    assert not ctrlr.after_deploy_unsuccessful.called
     assert not ctrlr.after_verify.called
+    assert not ctrlr.after_verify_unsuccessful.called
 
 
 ##################
@@ -394,7 +398,9 @@ def test_after_verify_failure():
 
     # Make sure both after_deploy and after_verify were called
     assert ctrlr.after_deploy.called
+    assert not ctrlr.after_deploy_unsuccessful.called
     assert ctrlr.after_verify.called
+    assert not ctrlr.after_verify_unsuccessful.called
 
 
 def test_after_verify_error():
@@ -406,7 +412,9 @@ def test_after_verify_error():
 
     # Make sure both after_deploy and after_verify were called
     assert ctrlr.after_deploy.called
+    assert not ctrlr.after_deploy_unsuccessful.called
     assert ctrlr.after_verify.called
+    assert not ctrlr.after_verify_unsuccessful.called
 
 
 ####################

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -347,6 +347,16 @@ def test_run_reconcile_rerun():
         ctrlr.run_reconcile(session)
 
 
+def test_setup_failure():
+    session = setup_session()
+    ctrlr = DummyController(setup_components_fail=True)
+    ctrlr.run_reconcile(session)
+
+    # TODO, NOTE: specifying setup_components_fail as True did not trigger after_deploy_unsuccessful ...
+    assert not ctrlr.after_deploy.called
+    assert ctrlr.after_deploy_unsuccessful.called
+
+
 ##################
 ## after_deploy ##
 ##################

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -347,16 +347,6 @@ def test_run_reconcile_rerun():
         ctrlr.run_reconcile(session)
 
 
-def test_setup_failure():
-    session = setup_session()
-    ctrlr = DummyController(setup_components_fail=True)
-    ctrlr.run_reconcile(session)
-
-    # TODO, NOTE: specifying setup_components_fail as True did not trigger after_deploy_unsuccessful ...
-    assert not ctrlr.after_deploy.called
-    assert ctrlr.after_deploy_unsuccessful.called
-
-
 ##################
 ## after_deploy ##
 ##################

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -266,7 +266,9 @@ def test_rollout_components():
 
     # Make sure the after_deploy and after_verify were called
     assert ctrlr.after_deploy.called
+    assert not ctrlr.after_deploy_unsuccessful.called
     assert ctrlr.after_verify.called
+    assert not ctrlr.after_verify_unsuccessful.called
 
     # Test completion state
     assert completion_state.deploy_completed()

--- a/tests/test_rollout_manager.py
+++ b/tests/test_rollout_manager.py
@@ -303,14 +303,14 @@ class TestRolloutManager:
         ctrlr = DummyController()
         ctrlr.setup_components(session)
 
-        try:
+        with pytest.raises(RolloutError):
             # Rollout should fail at phase1 (deployment) and raise RolloutError.
-            completion_state = ctrlr._rollout_components(session)
-        except RolloutError:
-            assert not ctrlr.after_deploy.called
-            assert ctrlr.after_deploy_unsuccessful.called
-            assert not ctrlr.after_deploy.called
-            assert not ctrlr.after_deploy.called
+            ctrlr._rollout_components(session)
+
+        assert not ctrlr.after_deploy.called
+        assert ctrlr.after_deploy_unsuccessful.called
+        assert not ctrlr.after_deploy.called
+        assert not ctrlr.after_deploy.called
 
     def test_rollout_deploy_incomplete(self):
         """Test the correct after_deploy, after_deploy_unsuccessful, after_verify,

--- a/tests/test_rollout_manager.py
+++ b/tests/test_rollout_manager.py
@@ -15,9 +15,19 @@ import alog
 
 # Local
 from oper8.dag import CompletionState, Node
-from oper8.exceptions import ClusterError, PreconditionError, VerificationError
+from oper8.exceptions import (
+    ClusterError,
+    PreconditionError,
+    RolloutError,
+    VerificationError,
+)
 from oper8.rollout_manager import RolloutManager
-from oper8.test_helpers.helpers import DummyNodeComponent, library_config, setup_session
+from oper8.test_helpers.helpers import (
+    DummyController,
+    DummyNodeComponent,
+    library_config,
+    setup_session,
+)
 
 ################################################################################
 ## Helpers #####################################################################
@@ -274,6 +284,33 @@ class TestRolloutManager:
         assert after_deploy_unsuccessful.called
         assert not after_verify.called
         assert not after_verify_unsuccessful.called
+
+    def test_deploy_throw_controller(self):
+        """Test that a throw during deploy is handled properly when rollout is triggered via controller"""
+        session = setup_session()
+
+        # Set up a linear set of components and configure the second-to-last to
+        # fail during deploy.
+        #
+        #    A -> B -x C
+        comp_a = DummyRolloutComponent("A")(session)
+        comp_b = DummyRolloutComponent("B")(session, deploy_fail=RuntimeError)
+        comp_c = DummyRolloutComponent("C")(session)
+        comps = [comp_a, comp_b, comp_c]
+        for i, comp in enumerate(comps[1:]):
+            session.add_component_dependency(comp, comps[i])
+
+        ctrlr = DummyController()
+        ctrlr.setup_components(session)
+
+        try:
+            # Rollout should fail at phase1 (deployment) and raise RolloutError.
+            completion_state = ctrlr._rollout_components(session)
+        except RolloutError:
+            assert not ctrlr.after_deploy.called
+            assert ctrlr.after_deploy_unsuccessful.called
+            assert not ctrlr.after_deploy.called
+            assert not ctrlr.after_deploy.called
 
     def test_rollout_deploy_incomplete(self):
         """Test the correct after_deploy, after_deploy_unsuccessful, after_verify,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/IBM/oper8/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## Related Issue

Follow up of https://github.com/IBM/oper8/pull/131

## Related PRs

This PR is not dependent on any other PR

## What this PR does / why we need it

New callbacks added at https://github.com/IBM/oper8/pull/131 were not triggered from controller. I have updated controller to resolve this issue. 

## Special notes for your reviewer

I have tried to add `ctrlr.after_deploy_unsuccessful.called` is True test case into `tests/test_controller.py`, but I could not figure out how to setup `ctrlr` which fails to at deploy phase. If you have any advise, please let me know.

## If applicable**
- [ ] this PR contains documentation
- [x] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

## What gif most accurately describes how I feel towards this PR?
![Example of a gif](
https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExZHJibjdicGQyYW04dW9sZ2N1emN3MndxNXRlMm5kYWNoNHc0czg2byZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/4SXW1rU9loG1HIXXg2/giphy.webp)



