### PR TITLE
Fix Spawn MP Context and Update Default 

### DIFF
--- a/oper8/config/config.yaml
+++ b/oper8/config/config.yaml
@@ -73,7 +73,7 @@ python_watch_manager:
   max_concurrent_reconciles: null
   reconcile_period: 10m
 
-  process_context: fork
+  process_context: spawn
   watch_dependent_resources: false
   subsystem_rollout: false
 

--- a/oper8/watch_manager/python_watch_manager/threads/reconcile.py
+++ b/oper8/watch_manager/python_watch_manager/threads/reconcile.py
@@ -9,6 +9,7 @@ from multiprocessing.connection import Connection
 from time import sleep
 from typing import Dict, List, Optional
 import multiprocessing
+import multiprocessing.forkserver
 import os
 import queue
 import threading
@@ -75,6 +76,13 @@ class ReconcileThread(
         context = config.python_watch_manager.process_context
         if context not in multiprocessing.get_all_start_methods():
             raise ConfigError(f"Invalid process_context: '{context}'")
+
+        if context == "fork":
+            log.warning(
+                "The fork multiprocessing context is known to cause deadlocks in certain"
+                " environments due to OpenSSL. Consider using spawn for more reliable"
+                " reconciling"
+            )
 
         self.spawn_ctx = multiprocessing.get_context(context)
 

--- a/oper8/watch_manager/python_watch_manager/threads/reconcile.py
+++ b/oper8/watch_manager/python_watch_manager/threads/reconcile.py
@@ -77,7 +77,7 @@ class ReconcileThread(
             raise ConfigError(f"Invalid process_context: '{context}'")
 
         self.spawn_ctx = multiprocessing.get_context(context)
-        
+
         # Setup required queues
         self.request_queue = self.spawn_ctx.Queue()
         self.logging_queue = self.spawn_ctx.Queue()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,11 @@ import pytest
 
 # Local
 from oper8.reconcile import ReconcileManager
-from oper8.test_helpers.helpers import configure_logging, version_safe_md5
+from oper8.test_helpers.helpers import (
+    config_detail_dict,
+    configure_logging,
+    version_safe_md5,
+)
 
 configure_logging()
 
@@ -24,6 +28,15 @@ def no_local_kubeconfig():
         "kubernetes.config.new_client_from_config", side_effect=RuntimeError
     ):
         yield
+
+@pytest.fixture(autouse=True)
+def fork_multiprocess():
+    """This fixture makes sure that we use fork for multiprocessing instead of
+    spawn. Spawn is more reliable with FIPs and OpenSSL but causes issues with
+    pickling objects.
+    """
+    # Don't use library_config since some tests read the config object directly
+    config_detail_dict.python_watch_manager.process_context = "fork"
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,11 +29,12 @@ def no_local_kubeconfig():
     ):
         yield
 
+
 @pytest.fixture(autouse=True)
 def fork_multiprocess():
     """This fixture makes sure that we use fork for multiprocessing instead of
-    spawn. Spawn is more reliable with FIPs and OpenSSL but causes issues with
-    pickling objects.
+    spawn. Spawn is more reliable with FIPs and OpenSSL but causes issues when
+    pickling mocked or patched objects.
     """
     # Don't use library_config since some tests read the config object directly
     config_detail_dict.python_watch_manager.process_context = "fork"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/IBM/oper8/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## Related Issue
Supports #?

## Related PRs
This PR is not dependent on any other PR

## What this PR does / why we need it
This PR updates the PWM to support the `spawn` multi-processing context and set's it as the default. This is to avoid openssl issues like this one https://github.com/openssl/openssl/issues/19066 which could cause a deadlock when trying to reconnect to the cluster

## Special notes for your reviewer

## If applicable**
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

## What gif most accurately describes how I feel towards this PR?
![Example of a gif](https://media.giphy.com/media/snwvCcEKk33Hy/giphy.gif)
