### PR TITLE
Documentation

### DIFF
--- a/.github/workflows/publish-document.yml
+++ b/.github/workflows/publish-document.yml
@@ -28,9 +28,7 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - name: Install MkDocs Dependencies
-        run: |
-          pip install mkdocs-material
-          pip install 'mkdocstrings[python]'
-      - name: Deploy to GitHub Pages
-        run: mkdocs gh-deploy --force
+      - name: Install mkdocs dependencies
+        run: pip install tox
+      - name: Deploy documentation to GitHub Pages
+        run: tox -e docs -- gh-deploy --force

--- a/.github/workflows/publish-document.yml
+++ b/.github/workflows/publish-document.yml
@@ -2,7 +2,6 @@ name: Publish document
 on:
   push:
     branches:
-      - master
       - main
 permissions:
   contents: write

--- a/.github/workflows/publish-document.yml
+++ b/.github/workflows/publish-document.yml
@@ -1,0 +1,37 @@
+name: Publish document
+on:
+  push:
+    branches:
+      - master
+      - main
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout Repository
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email github-actions[bot]@users.noreply.github.com
+      - uses: actions/setup-python@v5
+        name: Setup Python
+        with:
+          python-version: 3.12
+      - name: Set Cache ID
+        run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
+      - uses: actions/cache@v4
+        name: Restore/Save Cache
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache
+          restore-keys: |
+            mkdocs-material-
+      - name: Install MkDocs Dependencies
+        run: |
+          pip install mkdocs-material
+          pip install 'mkdocstrings[python]'
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ venv/
 
 # Setuptools scm version
 _version.py
+
+# mkdocs documentation
+/site

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,6 +156,31 @@ To format and lint the codes,
 tox -e fmt,lint
 ```
 
+## [Optional] Documentation setup
+
+This repository uses [mkdocs](https://github.com/mkdocs/mkdocs/tree/master) to generate a documentation from python docstring. As long as you write docstrings for your code, the document (API references section) will be automatically updated when the code is merged into `main` branch, so there is no need for you to do anything.
+
+If you want to manually edit the document, please run the following commands to setup the editing environment.
+
+```bash
+pip install mkdocs-material
+pip install 'mkdocstrings[python]'
+```
+
+You can edit the documentation at `docs` folder (i.e. `docs/index.md`) to update the document.
+
+In order to view the current documentation locally, run the following command. This will host the document at your local server.
+
+```bash
+mkdocs serve
+```
+
+For more information about mkdocs, please refer to their documentations:
+
+- mkdocs: https://github.com/mkdocs/mkdocs/tree/master
+- mkdocs material (material theme wrapper for mkdocs): https://github.com/squidfunk/mkdocs-material
+- mkdocstrings (plugin to automatically generate documentation from docstrings): https://github.com/mkdocstrings/mkdocstrings
+
 # Your First Contribution
 
 Would you like to help drive the community forward? We will help you understand the organization of the project and direct you to the best places to get started. You'll be able to pick up issues, write code to fix them, and get your work reviewed and merged.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,24 +156,26 @@ To format and lint the codes,
 tox -e fmt,lint
 ```
 
-## [Optional] Documentation setup
+This repository uses [mkdocs](https://github.com/mkdocs/mkdocs/tree/master) to generate a documentation from python docstring. As long as you write the docstrings for your code, the document (API references section) will be updated whenever you run `tox -e docs` command. The document will be automatically published when your PR is merged into `main` branch.
 
-This repository uses [mkdocs](https://github.com/mkdocs/mkdocs/tree/master) to generate a documentation from python docstring. As long as you write docstrings for your code, the document (API references section) will be automatically updated when the code is merged into `main` branch, so there is no need for you to do anything.
-
-If you want to manually edit the document, please run the following commands to setup the editing environment.
+To build the documentation based on your current codes, run the following command. This will outputs the documentation into `./site` folder.
 
 ```bash
-pip install mkdocs-material
-pip install 'mkdocstrings[python]'
+tox -e docs
 ```
 
-You can edit the documentation at `docs` folder (i.e. `docs/index.md`) to update the document.
-
-In order to view the current documentation locally, run the following command. This will host the document at your local server.
+To run other mkdocs command,
 
 ```bash
-mkdocs serve
+tox -e docs -- <mkdocs command>
+
+# For instance, serve the current documentation locally,
+tox -e docs -- serve
+...
+INFO    -  [17:35:25] Serving on http://127.0.0.1:8000/
 ```
+
+You can also manually edit or add pages to the documentation by modifying files under `./docs` folder.
 
 For more information about mkdocs, please refer to their documentations:
 

--- a/docs/API References.md
+++ b/docs/API References.md
@@ -1,0 +1,3 @@
+<!-- Auto generate API references with mkdocstrings https://mkdocstrings.github.io/usage/#usage -->
+
+::: oper8

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# Oper8
+
+Oper8 is a framework for writing kubernetes operators in python. It implements many common patterns used by large cloud applications that are reusable across many operator design patterns ([GitHub](https://github.com/IBM/oper8/tree/main)).
+
+For API details, please refer to the [API References](API References.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,31 @@
+site_name: "oper8"
+nav:
+  - Home: index.md
+  - API References: API References.md
+theme:
+  name: material
+  font:
+    text: IBM Plex Sans
+    code: IBM Plex Mono
+  palette:
+    # Dark Mode
+    - scheme: slate
+      toggle:
+        icon: material/weather-sunny
+        name: Dark mode
+      primary: black
+      accent: deep purple
+    # Light Mode
+    - scheme: default
+      toggle:
+        icon: material/weather-night
+        name: Light mode
+      primary: white
+      accent: indigo
+plugins:
+- search
+- mkdocstrings:
+    handlers:
+      python:
+        options:
+          show_submodules: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,9 +23,9 @@ theme:
       primary: white
       accent: indigo
 plugins:
-- search
-- mkdocstrings:
-    handlers:
-      python:
-        options:
-          show_submodules: true
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            show_submodules: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,9 +62,8 @@ dev-test = [
 ]
 
 dev-docs = [
-    "sphinx>=4.0.2,<9.0",
-    "sphinx-autoapi>=2.1.0",
-    "sphinx-rtd-theme>=1.2.1,<3.1.0",
+    "mkdocs-material>=9.5.46",
+    "mkdocstrings-python>=1.12.2"
 ]
 
 dev-fmt = [

--- a/scripts/document.sh
+++ b/scripts/document.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e
+BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$BASE_DIR"
+
+mkdocs_opt=("$@")
+
+if [[ ${#mkdocs_opt[@]} -eq 0 ]]; then
+    echo "No options provided. Running 'mkdocs build'..."
+    mkdocs build
+    exit 0
+fi
+
+# Modify set e because serve will be aborted with ctrl C.
+if [[ "${mkdocs_opt[0]}" == "serve" ]]; then
+    set +e
+    echo "Serving the documentation. Abort with ctrl C."
+fi
+
+echo "Running 'mkdocs ${mkdocs_opt[@]}'..."
+mkdocs "${mkdocs_opt[@]}"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py, lint, fmt
+envlist = py, lint, fmt, docs
 
 [testenv]
 description = run tests with pytest with coverage
@@ -20,16 +20,11 @@ allowlist_externals = ./scripts/run_tests.sh
 ; Without this, sdist packaging is tested so that's a start.
 package=wheel
 
-; TODO -- Enable docs!!
-; [testenv:docs]
-; recreate = True
-; extras = dev-docs
-; changedir = docs/source
-
-; ; Disabled '-W' flag as warnings in the files
-; ; TOTO: Add back in once build warnings fixed
-; commands =
-;   sphinx-build -E -a -b html -T . _build/html
+[testenv:docs]
+description = build documentation
+extras = dev-docs
+commands = ./scripts/document.sh {posargs}
+allowlist_externals = ./scripts/document.sh
 
 [testenv:fmt]
 description = format with pre-commit


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/IBM/oper8/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## What this PR does / why we need it

I have created a documentation for oper8.

It currently has descriptions of functions, classes, return values and input types. And they can be searched via UI. 

Those are generated from docstrings, and the build is also automated with github workflow, so all the dev need is to write some docstrings, and merge codes into main branch, then the document should be updated automatically.

Documentations are written under `docs` folder. 
- `docs/API References.md`
- `docs/index.md`

And github workflow is added to automatically publish the documentation to GitHub pages. 
- `.github/workflows/publish-document.yml`

Currently it is not published yet. In order to view the documentation locally, please follow `[Optional] Documentation setup` at `CONTRIBUTING.md`. Below are the screenshots of the documentation.

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/9c8af8e0-a2fa-480c-8f84-d486d916e347" />

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/b9a3b36f-2b9d-4dab-9ec4-ecfabc83c7bd" />

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/855dd436-59d2-4e0c-8330-2837cba54ee1" />

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/4b5c2938-ddbc-4417-9f24-767bbd893d43" />

The following tools are used:
- mkdocs: https://github.com/mkdocs/mkdocs/tree/master
- mkdocs material (material theme wrapper for mkdocs): https://github.com/squidfunk/mkdocs-material
- mkdocstrings (plugin to automatically generate documentation from docstrings): https://github.com/mkdocstrings/mkdocstrings

## Special notes for your reviewer

I would like to publish this documentation using github pages, but it seems I do not have necessary permission to do so. The setting is written at `.github/workflows/publish-document.yml`, so please setup the github pages if you can.

Also, feel free to update the documentation. I think we need something like getting started page to give user some simple examples to show how to use oper8. I would like to write this page by myself, but to be honest, I don't understand this library that well ..., so someone please make the page, or give me some advice 🙏.

## If applicable**
- [x] this PR contains documentation
- [ ] this PR has been tested for backwards compatibility

## What gif most accurately describes how I feel towards this PR?

![Example of a gif](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExbDJxMHI3emEwazFmOTZvamt2dm53M3czNHNmemozaDVhc2w0bDVudyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/c6W48VCLPF1l8Uu18A/200.webp)
