### PR TITLE
Pass completion result to after_deploy/after_verify

### DIFF
--- a/oper8/controller.py
+++ b/oper8/controller.py
@@ -152,7 +152,9 @@ class Controller(abc.ABC):
                 The current session containing the per-event configs
         """
 
-    def after_deploy(self, session: Session, deploy_completion_state: CompletionState) -> bool:
+    def after_deploy(
+        self, session: Session, deploy_completion_state: CompletionState
+    ) -> bool:
         """This allows children to inject logic that will run when the
         controller has finished deploying all components, but not necessarily
         verifying all of them. The default behavior is a no-op.
@@ -170,7 +172,9 @@ class Controller(abc.ABC):
         """
         return True
 
-    def after_deploy_unsuccessful(self, session: Session, failed: bool, deploy_completion_state: CompletionState) -> bool:
+    def after_deploy_unsuccessful(
+        self, session: Session, failed: bool, deploy_completion_state: CompletionState
+    ) -> bool:
         """This allows children to inject logic that will run when the
         controller has failed or could not finish deploying all components.
         The default behavior is a no-op.
@@ -193,7 +197,7 @@ class Controller(abc.ABC):
     def after_verify(
         self,
         session: Session,  # pylint: disable=unused-argument
-        verify_completion_state: CompletionState
+        verify_completion_state: CompletionState,
     ) -> bool:
         """This allows children to inject logic that will run when the
         controller has finished verifying all components. The default behavior
@@ -212,7 +216,9 @@ class Controller(abc.ABC):
         """
         return True
 
-    def after_verify_unsuccessful(self, session: Session, failed: bool, verify_completion_state: CompletionState) -> bool:
+    def after_verify_unsuccessful(
+        self, session: Session, failed: bool, verify_completion_state: CompletionState
+    ) -> bool:
         """This allows children to inject logic that will run when the
         controller has finished deploying all components but failed to verify.
         The default behavior is a no-op.

--- a/oper8/controller.py
+++ b/oper8/controller.py
@@ -152,7 +152,7 @@ class Controller(abc.ABC):
                 The current session containing the per-event configs
         """
 
-    def after_deploy(self, session: Session) -> bool:
+    def after_deploy(self, session: Session, deploy_completion_state: CompletionState) -> bool:
         """This allows children to inject logic that will run when the
         controller has finished deploying all components, but not necessarily
         verifying all of them. The default behavior is a no-op.
@@ -160,6 +160,8 @@ class Controller(abc.ABC):
         Args:
             session:  Session
                 The current reconciliation session
+            deploy_completion_state: CompletionState
+                Completion state of the last deployment
 
         Returns:
             success:  bool
@@ -168,7 +170,7 @@ class Controller(abc.ABC):
         """
         return True
 
-    def after_deploy_unsuccessful(self, session: Session, failed: bool) -> bool:
+    def after_deploy_unsuccessful(self, session: Session, failed: bool, deploy_completion_state: CompletionState) -> bool:
         """This allows children to inject logic that will run when the
         controller has failed or could not finish deploying all components.
         The default behavior is a no-op.
@@ -178,6 +180,8 @@ class Controller(abc.ABC):
                 The current reconciliation session
             failed:  bool
                 Indicator of whether or not the termination was a failure
+            deploy_completion_state: CompletionState
+                Completion state of the last deployment
 
         Returns:
             success:  bool
@@ -186,6 +190,7 @@ class Controller(abc.ABC):
         """
         return True
 
+    # TODO get verify_completion_state
     def after_verify(
         self,
         session: Session,  # pylint: disable=unused-argument

--- a/oper8/controller.py
+++ b/oper8/controller.py
@@ -198,6 +198,7 @@ class Controller(abc.ABC):
         self,
         session: Session,  # pylint: disable=unused-argument
         verify_completion_state: CompletionState,
+        deploy_completion_state: CompletionState,
     ) -> bool:
         """This allows children to inject logic that will run when the
         controller has finished verifying all components. The default behavior
@@ -208,6 +209,8 @@ class Controller(abc.ABC):
                 The current reconciliation session
             verify_completion_state: CompletionState
                 Completion state of the last verification
+            deploy_completion_state: CompletionState
+                Completion state of the last deployment
 
         Returns:
             success:  bool
@@ -217,7 +220,11 @@ class Controller(abc.ABC):
         return True
 
     def after_verify_unsuccessful(
-        self, session: Session, failed: bool, verify_completion_state: CompletionState
+        self,
+        session: Session,
+        failed: bool,
+        verify_completion_state: CompletionState,
+        deploy_completion_state: CompletionState,
     ) -> bool:
         """This allows children to inject logic that will run when the
         controller has finished deploying all components but failed to verify.
@@ -230,6 +237,8 @@ class Controller(abc.ABC):
                 Indicator of whether or not the termination was a failure
             verify_completion_state: CompletionState
                 Completion state of the last verification
+            deploy_completion_state: CompletionState
+                Completion state of the last deployment
 
         Returns:
             success:  bool

--- a/oper8/controller.py
+++ b/oper8/controller.py
@@ -190,10 +190,10 @@ class Controller(abc.ABC):
         """
         return True
 
-    # TODO get verify_completion_state
     def after_verify(
         self,
         session: Session,  # pylint: disable=unused-argument
+        verify_completion_state: CompletionState
     ) -> bool:
         """This allows children to inject logic that will run when the
         controller has finished verifying all components. The default behavior
@@ -202,6 +202,8 @@ class Controller(abc.ABC):
         Args:
             session:  Session
                 The current reconciliation session
+            verify_completion_state: CompletionState
+                Completion state of the last verification
 
         Returns:
             success:  bool
@@ -210,7 +212,7 @@ class Controller(abc.ABC):
         """
         return True
 
-    def after_verify_unsuccessful(self, session: Session, failed: bool) -> bool:
+    def after_verify_unsuccessful(self, session: Session, failed: bool, verify_completion_state: CompletionState) -> bool:
         """This allows children to inject logic that will run when the
         controller has finished deploying all components but failed to verify.
         The default behavior is a no-op.
@@ -220,6 +222,8 @@ class Controller(abc.ABC):
                 The current reconciliation session
             failed:  bool
                 Indicator of whether or not the termination was a failure
+            verify_completion_state: CompletionState
+                Completion state of the last verification
 
         Returns:
             success:  bool

--- a/oper8/rollout_manager.py
+++ b/oper8/rollout_manager.py
@@ -459,7 +459,10 @@ class RolloutManager:
                 try:
                     is_after_verify_unsuccessful_completed = (
                         self._after_verify_unsuccessful(
-                            self._session, phase3_failed, verify_completion_state
+                            self._session,
+                            phase3_failed,
+                            verify_completion_state,
+                            deploy_completion_state,
                         )
                     )
                 except TypeError:
@@ -484,7 +487,7 @@ class RolloutManager:
             try:
                 try:
                     phase4_complete = self._after_verify(
-                        self._session, verify_completion_state
+                        self._session, verify_completion_state, deploy_completion_state
                     )
                 except TypeError:
                     log.warning(

--- a/oper8/rollout_manager.py
+++ b/oper8/rollout_manager.py
@@ -326,7 +326,9 @@ class RolloutManager:
             log.debug2("Running after-deploy-unsuccessful")
             try:
                 is_after_deploy_unsuccessful_completed = (
-                    self._after_deploy_unsuccessful(self._session, phase1_failed, deploy_completion_state)
+                    self._after_deploy_unsuccessful(
+                        self._session, phase1_failed, deploy_completion_state
+                    )
                 )
                 if not is_after_deploy_unsuccessful_completed:
                     phase2_exception = VerificationError(
@@ -344,7 +346,9 @@ class RolloutManager:
         if phase1_complete and self._after_deploy:
             log.debug2("Running after-deploy")
             try:
-                phase2_complete = self._after_deploy(self._session, deploy_completion_state)
+                phase2_complete = self._after_deploy(
+                    self._session, deploy_completion_state
+                )
                 if not phase2_complete:
                     phase2_exception = VerificationError(
                         "After-deploy verification failed"
@@ -436,7 +440,9 @@ class RolloutManager:
             log.debug("Running after-verify-unsuccessful")
             try:
                 is_after_verify_unsuccessful_completed = (
-                    self._after_verify_unsuccessful(self._session, phase3_failed, verify_completion_state)
+                    self._after_verify_unsuccessful(
+                        self._session, phase3_failed, verify_completion_state
+                    )
                 )
                 if not is_after_verify_unsuccessful_completed:
                     phase4_exception = VerificationError(
@@ -450,7 +456,9 @@ class RolloutManager:
         if phase3_complete and self._after_verify:
             log.debug("Running after-verify")
             try:
-                phase4_complete = self._after_verify(self._session, verify_completion_state)
+                phase4_complete = self._after_verify(
+                    self._session, verify_completion_state
+                )
                 if not phase4_complete:
                     phase4_exception = VerificationError("After-verify failed")
             except Exception as err:  # pylint: disable=broad-except

--- a/oper8/rollout_manager.py
+++ b/oper8/rollout_manager.py
@@ -436,7 +436,7 @@ class RolloutManager:
             log.debug("Running after-verify-unsuccessful")
             try:
                 is_after_verify_unsuccessful_completed = (
-                    self._after_verify_unsuccessful(self._session, phase3_failed)
+                    self._after_verify_unsuccessful(self._session, phase3_failed, verify_completion_state)
                 )
                 if not is_after_verify_unsuccessful_completed:
                     phase4_exception = VerificationError(
@@ -450,7 +450,7 @@ class RolloutManager:
         if phase3_complete and self._after_verify:
             log.debug("Running after-verify")
             try:
-                phase4_complete = self._after_verify(self._session)
+                phase4_complete = self._after_verify(self._session, verify_completion_state)
                 if not phase4_complete:
                     phase4_exception = VerificationError("After-verify failed")
             except Exception as err:  # pylint: disable=broad-except

--- a/oper8/rollout_manager.py
+++ b/oper8/rollout_manager.py
@@ -326,7 +326,7 @@ class RolloutManager:
             log.debug2("Running after-deploy-unsuccessful")
             try:
                 is_after_deploy_unsuccessful_completed = (
-                    self._after_deploy_unsuccessful(self._session, phase1_failed)
+                    self._after_deploy_unsuccessful(self._session, phase1_failed, deploy_completion_state)
                 )
                 if not is_after_deploy_unsuccessful_completed:
                     phase2_exception = VerificationError(
@@ -344,7 +344,7 @@ class RolloutManager:
         if phase1_complete and self._after_deploy:
             log.debug2("Running after-deploy")
             try:
-                phase2_complete = self._after_deploy(self._session)
+                phase2_complete = self._after_deploy(self._session, deploy_completion_state)
                 if not phase2_complete:
                     phase2_exception = VerificationError(
                         "After-deploy verification failed"

--- a/oper8/rollout_manager.py
+++ b/oper8/rollout_manager.py
@@ -6,7 +6,6 @@ dependency management for rollout
 # Standard
 from functools import partial
 from typing import Callable, Optional
-import inspect
 
 # First Party
 import alog
@@ -19,9 +18,6 @@ from .exceptions import Oper8Error, VerificationError
 from .session import Session
 
 log = alog.use_channel("ROLMGR")
-# New argument introduced at oper8 v0.1.33 for after_deploy or after_verify functions.
-DEPLOY_COMPLETION_STATE_ARG_NAME = "deploy_completion_state"
-VERIFY_COMPLETION_STATE_ARG_NAME = "verify_completion_state"
 
 ## Rollout Functions ###########################################################
 
@@ -329,17 +325,14 @@ class RolloutManager:
         if (not phase1_complete or phase1_failed) and self._after_deploy_unsuccessful:
             log.debug2("Running after-deploy-unsuccessful")
             try:
-                # Check DEPLOY_COMPLETION_STATE_ARG_NAME argument for backward compatibility.
-                if (
-                    DEPLOY_COMPLETION_STATE_ARG_NAME
-                    in inspect.signature(self._after_deploy_unsuccessful).parameters
-                ):
+                # Check deploy_completion_state argument for backward compatibility.
+                try:
                     is_after_deploy_unsuccessful_completed = (
                         self._after_deploy_unsuccessful(
                             self._session, phase1_failed, deploy_completion_state
                         )
                     )
-                else:
+                except TypeError:
                     log.warning(
                         "Detected old after_deploy function. Please migrate oper8 to ^0.1.33."
                     )
@@ -363,14 +356,11 @@ class RolloutManager:
         if phase1_complete and self._after_deploy:
             log.debug2("Running after-deploy")
             try:
-                if (
-                    DEPLOY_COMPLETION_STATE_ARG_NAME
-                    in inspect.signature(self._after_deploy).parameters
-                ):
+                try:
                     phase2_complete = self._after_deploy(
                         self._session, deploy_completion_state
                     )
-                else:
+                except TypeError:
                     log.warning(
                         "Detected old after_deploy function. Please migrate oper8 to ^0.1.33."
                     )
@@ -466,16 +456,13 @@ class RolloutManager:
         ) and self._after_verify_unsuccessful:
             log.debug("Running after-verify-unsuccessful")
             try:
-                if (
-                    VERIFY_COMPLETION_STATE_ARG_NAME
-                    in inspect.signature(self._after_verify_unsuccessful).parameters
-                ):
+                try:
                     is_after_verify_unsuccessful_completed = (
                         self._after_verify_unsuccessful(
                             self._session, phase3_failed, verify_completion_state
                         )
                     )
-                else:
+                except TypeError:
                     log.warning(
                         "Detected old after_verify function. Please migrate oper8 to ^0.1.33."
                     )
@@ -495,14 +482,11 @@ class RolloutManager:
         if phase3_complete and self._after_verify:
             log.debug("Running after-verify")
             try:
-                if (
-                    VERIFY_COMPLETION_STATE_ARG_NAME
-                    in inspect.signature(self._after_verify).parameters
-                ):
+                try:
                     phase4_complete = self._after_verify(
                         self._session, verify_completion_state
                     )
-                else:
+                except TypeError:
                     log.warning(
                         "Detected old after_verify function. Please migrate oper8 to ^0.1.33."
                     )

--- a/tests/test_rollout_manager.py
+++ b/tests/test_rollout_manager.py
@@ -528,8 +528,8 @@ class TestRolloutManager:
         def new_after_deploy(
             session: Session, deploy_completion_state: CompletionState
         ) -> bool:
-            assert session is not None
-            assert deploy_completion_state is not None
+            assert isinstance(session, Session)
+            assert isinstance(deploy_completion_state, CompletionState)
             return False
 
         mock_new_after_deploy = mock.Mock()
@@ -562,7 +562,7 @@ class TestRolloutManager:
 
         # Prepare mock functions.
         def old_after_deploy(session: Session) -> bool:
-            assert session is not None
+            assert isinstance(session, Session)
             return False
 
         mock_old_after_deploy = mock.Mock()
@@ -608,9 +608,9 @@ class TestRolloutManager:
         def new_after_deploy_unsuccessful(
             session: Session, failed: bool, deploy_completion_state: CompletionState
         ) -> bool:
-            assert session is not None
-            assert failed is not None
-            assert deploy_completion_state is not None
+            assert isinstance(session, Session)
+            assert isinstance(failed, bool)
+            assert isinstance(deploy_completion_state, CompletionState)
             return False
 
         mock_new_after_deploy_unsuccessful = mock.Mock()
@@ -653,8 +653,8 @@ class TestRolloutManager:
         after_deploy = mock.Mock(return_value=True)
 
         def old_after_deploy_unsuccessful(session: Session, failed: bool) -> bool:
-            assert session is not None
-            assert failed is not None
+            assert isinstance(session, Session)
+            assert isinstance(failed, bool)
             return False
 
         mock_old_after_deploy_unsuccessful = mock.Mock()
@@ -836,9 +836,9 @@ class TestRolloutManager:
             verify_completion_state: CompletionState,
             deploy_completion_state: CompletionState,
         ):
-            assert session is not None
-            assert verify_completion_state is not None
-            assert deploy_completion_state is not None
+            assert isinstance(session, Session)
+            assert isinstance(verify_completion_state, CompletionState)
+            assert isinstance(deploy_completion_state, CompletionState)
             return False
 
         mock_new_after_verify = mock.Mock()
@@ -883,7 +883,7 @@ class TestRolloutManager:
         def old_after_verify(
             session: Session,
         ):
-            assert session is not None
+            assert isinstance(session, Session)
             return False
 
         mock_old_after_verify = mock.Mock()
@@ -941,10 +941,10 @@ class TestRolloutManager:
             verify_completion_state: CompletionState,
             deploy_completion_state: CompletionState,
         ) -> bool:
-            assert session is not None
-            assert failed is not None
-            assert verify_completion_state is not None
-            assert deploy_completion_state is not None
+            assert isinstance(session, Session)
+            assert isinstance(failed, bool)
+            assert isinstance(verify_completion_state, CompletionState)
+            assert isinstance(deploy_completion_state, CompletionState)
             return False
 
         mock_new_after_verify_unsuccessful = mock.Mock()
@@ -994,8 +994,8 @@ class TestRolloutManager:
         after_verify = mock.Mock(return_value=True)
 
         def old_after_verify_unsuccessful(session: Session, failed: bool) -> bool:
-            assert session is not None
-            assert failed is not None
+            assert isinstance(session, Session)
+            assert isinstance(failed, bool)
             return False
 
         mock_old_after_verify_unsuccessful = mock.Mock()

--- a/tests/test_rollout_manager.py
+++ b/tests/test_rollout_manager.py
@@ -5,8 +5,8 @@ Test the rollout manager's functionality
 # Standard
 from functools import partial
 from unittest import mock
-import time
 import logging
+import time
 
 # Third Party
 import pytest
@@ -525,10 +525,13 @@ class TestRolloutManager:
         comp = DummyRolloutComponent("A")(session)
 
         # Prepare mock functions.
-        def new_after_deploy(session: Session, deploy_completion_state: CompletionState) -> bool:
+        def new_after_deploy(
+            session: Session, deploy_completion_state: CompletionState
+        ) -> bool:
             assert session is not None
             assert deploy_completion_state is not None
             return False
+
         mock_new_after_deploy = mock.Mock()
         mock_new_after_deploy.new_after_deploy.side_effect = new_after_deploy
         after_deploy_unsuccessful = mock.Mock(return_value=True)
@@ -561,6 +564,7 @@ class TestRolloutManager:
         def old_after_deploy(session: Session) -> bool:
             assert session is not None
             return False
+
         mock_old_after_deploy = mock.Mock()
         mock_old_after_deploy.old_after_deploy.side_effect = old_after_deploy
         after_deploy_unsuccessful = mock.Mock(return_value=True)
@@ -573,14 +577,13 @@ class TestRolloutManager:
         )
         completion_state = mgr.rollout()
         log.debug2(completion_state)
-        
+
         # Should warn user to migrate if old after_deploy function is used.
         assert "Please migrate" in caplog.text
         assert isinstance(completion_state.exception, VerificationError)
 
         assert mock_old_after_deploy.old_after_deploy.called
         assert not after_deploy_unsuccessful.called
-
 
     def test_after_deploy_non_oper8_error(self):
         """Test that when after_deploy raises a non-oper8 error, the rollout is
@@ -738,14 +741,15 @@ class TestRolloutManager:
         after_deploy_unsuccessful = mock.Mock(return_value=True)
 
         def new_after_verify(
-                session: Session, 
-                verify_completion_state: CompletionState,
-                deploy_completion_state: CompletionState
-            ):
+            session: Session,
+            verify_completion_state: CompletionState,
+            deploy_completion_state: CompletionState,
+        ):
             assert session is not None
             assert verify_completion_state is not None
             assert deploy_completion_state is not None
             return False
+
         mock_new_after_verify = mock.Mock()
         mock_new_after_verify.new_after_verify.side_effect = new_after_verify
 
@@ -786,10 +790,11 @@ class TestRolloutManager:
         after_deploy_unsuccessful = mock.Mock(return_value=True)
 
         def old_after_verify(
-                session: Session, 
-            ):
+            session: Session,
+        ):
             assert session is not None
             return False
+
         mock_old_after_verify = mock.Mock()
         mock_old_after_verify.old_after_verify.side_effect = old_after_verify
 

--- a/tests/test_rollout_manager.py
+++ b/tests/test_rollout_manager.py
@@ -546,6 +546,36 @@ class TestRolloutManager:
         assert mock_new_after_deploy.new_after_deploy.called
         assert not after_deploy_unsuccessful.called
 
+    def test_after_deploy_backward_compatibility(self):
+        """
+        New arguments are introduced to after_deploy/after_verify callbacks with oper8 v0.1.33.
+        Test if the new argument is received with new callbacks, and old callbacks can still be used without it.
+        """
+        session = setup_session()
+        comp = DummyRolloutComponent("A")(session)
+
+        # Prepare mock functions.
+        def old_after_deploy(session: Session) -> bool:
+            assert session is not None
+            return False
+        mock_old_after_deploy = mock.Mock()
+        mock_old_after_deploy.old_after_deploy.side_effect = old_after_deploy
+        after_deploy_unsuccessful = mock.Mock(return_value=True)
+
+        # Run rollout.
+        mgr = RolloutManager(
+            session,
+            after_deploy=mock_old_after_deploy.old_after_deploy,
+            after_deploy_unsuccessful=after_deploy_unsuccessful,
+        )
+        completion_state = mgr.rollout()
+        log.debug2(completion_state)
+        assert isinstance(completion_state.exception, VerificationError)
+
+        # Check if the expected after_deploy callbacks are called.
+        assert mock_old_after_deploy.old_after_deploy.called
+        assert not after_deploy_unsuccessful.called
+
 
     def test_after_deploy_non_oper8_error(self):
         """Test that when after_deploy raises a non-oper8 error, the rollout is


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/IBM/oper8/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## Related Issue
No related issue

## Related PRs
This PR is not dependent on any other PR

## What this PR does / why we need it

Passes the latest completion states to `controller.after_deploy` or `controller._after_verify` functions. This completion states could be useful to judge about the latest reconciliation result, such as determining which node was successful to deploy or not.

## Special notes for your reviewer

## If applicable**
- [x] this PR contains documentation (as doc strings)
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility (`tox -e py312` passed)

## What gif most accurately describes how I feel towards this PR?
![Example of a gif](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExZjF6cWdwYW14NHlianQ4cTAwOW9nczRxdnNmbXFhYTd2Ymx3MnluNiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xTiTnsjejeMJNBiP5u/giphy.gif)
