### PR TITLE
Log the session graph

### DIFF
--- a/oper8/controller.py
+++ b/oper8/controller.py
@@ -375,6 +375,7 @@ class Controller(abc.ABC):
         dependencies between them
         """
         log.debug("Rolling out %s", str(self))
+        log.debug3("Session dependency DAG: %s", str(session.graph))
 
         # Set up the deployment manager and run the rollout
         rollout_manager = RolloutManager(

--- a/tests/dag/test_graph.py
+++ b/tests/dag/test_graph.py
@@ -43,11 +43,15 @@ def test_add_node_dependency():
     node_a = Node("a")
     node_b = Node("b")
     node_c = Node("c")
+    node_d = Node("d")
     graph.add_node(node_a)
     graph.add_node(node_b)
     graph.add_node(node_c)
+    graph.add_node(node_d)
     graph.add_node_dependency(node_a, node_b)
     graph.add_node_dependency(node_a, node_c, "testdata")
+    graph.add_node_dependency(node_b, node_c)
+    graph.add_node_dependency(node_c, node_d)
 
     assert node_a.get_children() == [(node_b, None), (node_c, "testdata")]
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/IBM/oper8/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## Related Issue
No related issue.

## Related PRs
No related PR.

## What this PR does / why we need it
Log the session graph when the log level is set to debug3. I think the graph contains useful information such as component dependency, and should be visible to the user. 

I also added a node and some edges to the existing test to see how the graph is represented when it became complicated. But this is not the focus of this PR, so I am fine dropping this change. 

## Special notes for your reviewer

## If applicable**
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility

## What gif most accurately describes how I feel towards this PR?
![Example of a gif](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExc202ZGQ1MWh3N3E0MjNwYWlrdzBma3gxZ2liaHRvNGdtYTNmNTM5byZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ikONXvk02wQmY/giphy.gif)
